### PR TITLE
Added request headers in ScriptUtil.groovy

### DIFF
--- a/core/src/main/groovy/com/gatehill/imposter/script/ScriptUtil.groovy
+++ b/core/src/main/groovy/com/gatehill/imposter/script/ScriptUtil.groovy
@@ -1,6 +1,7 @@
 package com.gatehill.imposter.script
 
 import io.vertx.ext.web.RoutingContext
+import io.vertx.core.http.HttpHeaders
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 
@@ -55,6 +56,7 @@ class ScriptUtil {
         request.put "method", "${-> routingContext.request().method().name()}"
         request.put "uri", "${-> routingContext.request().absoluteURI()}"
         request.put "body", "${-> routingContext.getBodyAsString()}"
+		request.put "headers", -> routingContext.request().headers()
         context.put "request", unmodifiableMap(request)
 
         // additional context

--- a/core/src/main/groovy/com/gatehill/imposter/script/ScriptUtil.groovy
+++ b/core/src/main/groovy/com/gatehill/imposter/script/ScriptUtil.groovy
@@ -1,7 +1,6 @@
 package com.gatehill.imposter.script
 
 import io.vertx.ext.web.RoutingContext
-import io.vertx.core.http.HttpHeaders
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 
@@ -56,7 +55,7 @@ class ScriptUtil {
         request.put "method", "${-> routingContext.request().method().name()}"
         request.put "uri", "${-> routingContext.request().absoluteURI()}"
         request.put "body", "${-> routingContext.getBodyAsString()}"
-		request.put "headers", -> routingContext.request().headers()
+		request.put "headers", routingContext.request().headers()
         context.put "request", unmodifiableMap(request)
 
         // additional context

--- a/plugin/openapi/src/test/java/com/gatehill/imposter/plugin/openapi/OpenApiPluginImplTest.java
+++ b/plugin/openapi/src/test/java/com/gatehill/imposter/plugin/openapi/OpenApiPluginImplTest.java
@@ -169,4 +169,16 @@ public class OpenApiPluginImplTest extends BaseVerticleTest {
         testContext.assertTrue(combined.getPaths().keySet().contains("/simple/apis"));
         testContext.assertTrue(combined.getPaths().keySet().contains("/api/pets"));
     }
+
+    @Test
+    public void testRequestWithHeaders() throws Exception {
+        given()
+            .log().everything()
+            .accept(ContentType.TEXT)
+            .when()
+            .header("Authorization", "AUTH_HEADER")
+            .get("/simple/apis")
+            .then()
+            .statusCode(equalTo(HttpUtil.HTTP_NO_CONTENT));
+    }
 }

--- a/plugin/openapi/src/test/resources/config/openapi-plugin.groovy
+++ b/plugin/openapi/src/test/resources/config/openapi-plugin.groovy
@@ -1,3 +1,5 @@
+import io.vertx.core.http.HttpHeaders
+
 // Example of returning a specific status code, to control which
 // specification example is returned in the response.
 
@@ -11,7 +13,17 @@ if (context.request.uri ==~ /(.*)\/apis$/) {
                     withStatusCode 201
                 }
                 break
-
+            case 'GET':
+                if(context.request.headers.get(HttpHeaders.AUTHORIZATION) == "AUTH_HEADER") {
+                    respond {
+                        withStatusCode 204
+                    }
+                } else {
+                    respond {
+                        usingDefaultBehaviour()
+                    }
+                }
+                break
             default:
                 // fallback to specification examples
                 respond {

--- a/plugin/rest/src/test/java/com/gatehill/imposter/plugin/rest/RestPluginTest.java
+++ b/plugin/rest/src/test/java/com/gatehill/imposter/plugin/rest/RestPluginTest.java
@@ -115,4 +115,13 @@ public class RestPluginTest extends BaseVerticleTest {
                 .then()
                 .statusCode(equalTo(HttpUtil.HTTP_NOT_FOUND));
     }
+
+    @Test
+    public void testRequestWithHeaders() throws Exception {
+        given().when()
+                .header("Authorization", "AUTH_HEADER")
+                .get("/scripted?with-auth")
+                .then()
+                .statusCode(equalTo(HttpUtil.HTTP_NO_CONTENT));
+    }
 }

--- a/plugin/rest/src/test/resources/config/rest-plugin.groovy
+++ b/plugin/rest/src/test/resources/config/rest-plugin.groovy
@@ -1,5 +1,6 @@
 // Example of returning a specific status code or response file,
 // based on URI parameters or the absolute URI.
+import io.vertx.core.http.HttpHeaders
 
 switch (context.request.uri) {
     case ~/.*bad/:
@@ -7,6 +8,21 @@ switch (context.request.uri) {
         respond {
             withStatusCode 400
             immediately()
+        }
+        break
+    case ~/.*with-auth/:
+        if(context.request.headers.get(HttpHeaders.AUTHORIZATION) == "AUTH_HEADER"){
+            // HTTP Status-Code 204: No Content.
+            respond {
+                withStatusCode 204
+                immediately()
+            }
+        } else {
+            // HTTP Status-Code 400: Bad Request.
+            respond {
+                withStatusCode 400
+                immediately()
+            }
         }
         break
 


### PR DESCRIPTION
Just exposed the headers for the groovy scripts in order to enable further flexibility in mocking the response files.