### PR TITLE
Fix openapi docker example

### DIFF
--- a/docs/openapi_plugin.md
+++ b/docs/openapi_plugin.md
@@ -51,7 +51,9 @@ Docker example:
 
     docker run -ti -p 8443:8443 \
         -v $(pwd)/config:/opt/imposter/config \
-        outofcoffee/imposter-openapi
+        outofcoffee/imposter-openapi \
+        --plugin com.gatehill.imposter.plugin.openapi.OpenApiPluginImpl \
+        --configDir /opt/imposter/config
 
 Standalone Java example:
 


### PR DESCRIPTION
I was trying to the docker image with the openapi example but it wasn't loading the openapi plugin. I managed to fix it by passing the params described in the jar example.