### PR TITLE
0023 - add json content type to sfdc oauth response which is json

### DIFF
--- a/plugin/sfdc/src/main/java/com/gatehill/imposter/plugin/sfdc/SfdcPluginImpl.java
+++ b/plugin/sfdc/src/main/java/com/gatehill/imposter/plugin/sfdc/SfdcPluginImpl.java
@@ -64,6 +64,7 @@ public class SfdcPluginImpl extends ConfiguredPlugin<SfdcPluginConfig> implement
             final JsonObject authResponse = new JsonObject();
             authResponse.put("access_token", "dummyAccessToken");
             authResponse.put("instance_url", imposterConfig.getServerUrl());
+            routingContext.response().putHeader(CONTENT_TYPE, CONTENT_TYPE_JSON);
             routingContext.response().end(authResponse.encode());
         }));
 


### PR DESCRIPTION
Using the force api, i noticed that the json response from the oauth request caused an error because the response didn't have the content type header.  This PR adds that header and allows the response to be deserialised from json.