### PR TITLE
Supports object examples in OpenAPI plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 *.iml
 .gradletasknamecache
 .vertx/
+out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- ...
+- Adds support for object response examples in the OpenAPI plugin.
 
 ## [0.7.0] - 2019-08-03
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ subprojects {
         version_restAssured = '2.9.0'
         version_groovy = '2.4.12'
         version_args4j = '2.33'
+        version_jackson = '2.9.0'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     
     compile "org.apache.logging.log4j:log4j-core:$version_log4j"
     compile "org.codehaus.groovy:groovy-all:$version_groovy"
+    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$version_jackson"
 
     testCompile "junit:junit:$version_junit"
 }

--- a/core/src/main/groovy/com/gatehill/imposter/Imposter.java
+++ b/core/src/main/groovy/com/gatehill/imposter/Imposter.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 
 import static com.gatehill.imposter.util.FileUtil.CONFIG_FILE_SUFFIX;
 import static com.gatehill.imposter.util.HttpUtil.BIND_ALL_HOSTS;
-import static com.gatehill.imposter.util.MapUtil.MAPPER;
+import static com.gatehill.imposter.util.MapUtil.JSON_MAPPER;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
@@ -237,7 +237,7 @@ public class Imposter {
                     LOGGER.debug("Loading configuration file: {}", configFile);
                     configCount++;
 
-                    final BaseConfig config = MAPPER.readValue(configFile, BaseConfig.class);
+                    final BaseConfig config = JSON_MAPPER.readValue(configFile, BaseConfig.class);
                     config.setParentDir(configFile.getParentFile());
 
                     List<File> pluginConfigs = allPluginConfigs.get(config.getPluginClass());

--- a/core/src/main/groovy/com/gatehill/imposter/plugin/config/ConfiguredPlugin.java
+++ b/core/src/main/groovy/com/gatehill/imposter/plugin/config/ConfiguredPlugin.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.gatehill.imposter.util.MapUtil.MAPPER;
+import static com.gatehill.imposter.util.MapUtil.JSON_MAPPER;
 
 /**
  * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
@@ -27,7 +27,7 @@ public abstract class ConfiguredPlugin<T extends BaseConfig> implements Plugin, 
         final List<T> configs = configFiles.stream()
                 .map(file -> {
                     try {
-                        final T config = MAPPER.readValue(file, getConfigClass());
+                        final T config = JSON_MAPPER.readValue(file, getConfigClass());
                         config.setParentDir(file.getParentFile());
                         return config;
 

--- a/core/src/main/groovy/com/gatehill/imposter/util/MapUtil.java
+++ b/core/src/main/groovy/com/gatehill/imposter/util/MapUtil.java
@@ -3,16 +3,18 @@ package com.gatehill.imposter.util;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 
 /**
  * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
  */
 public final class MapUtil {
-    public static final ObjectMapper MAPPER = new ObjectMapper();
+    public static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    public static final ObjectMapper YAML_MAPPER = new YAMLMapper();
 
     static {
-        MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        MAPPER.enable(SerializationFeature.INDENT_OUTPUT);
+        JSON_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        JSON_MAPPER.enable(SerializationFeature.INDENT_OUTPUT);
     }
 
     private MapUtil() {}

--- a/docs/openapi_plugin.md
+++ b/docs/openapi_plugin.md
@@ -70,3 +70,27 @@ at their respective endpoints under
 
 For specific information about the endpoints, see the interactive sandbox at
 [http://localhost:8443/_spec](http://localhost:8443/_spec).
+
+## Object response examples
+
+Imposter has limited support for response examples defined as objects, for example an API specification like [object-examples.yaml](../plugin/openapi/src/test/resources/config/object-examples.yaml).
+
+The salient part of the response is as follows:
+
+```yaml
+responses:
+  "200":
+    description: team response
+    schema:
+      type: object
+      items:
+        $ref: '#/definitions/Team'
+    examples:
+      application/json:
+        id: 10
+        name: Engineering
+```
+
+> Note: the JSON example is specified as an object.
+
+Imposter currently supports JSON and YAML serialised content types in the response if they are specified in this way. If you want to return a different format, return a literal string, such as those above.

--- a/plugin/hbase/src/main/java/com/gatehill/imposter/plugin/hbase/service/serialisation/JsonSerialisationServiceImpl.java
+++ b/plugin/hbase/src/main/java/com/gatehill/imposter/plugin/hbase/service/serialisation/JsonSerialisationServiceImpl.java
@@ -39,7 +39,7 @@ public class JsonSerialisationServiceImpl implements SerialisationService, Deser
     @Override
     public MockScanner decodeScanner(RoutingContext routingContext) {
         try {
-            return MapUtil.MAPPER.readValue(routingContext.getBody().getBytes(), MockScanner.class);
+            return MapUtil.JSON_MAPPER.readValue(routingContext.getBody().getBytes(), MockScanner.class);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/plugin/openapi/src/test/resources/config/object-examples.yaml
+++ b/plugin/openapi/src/test/resources/config/object-examples.yaml
@@ -1,0 +1,37 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Object examples
+basePath: /objects
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /team:
+    get:
+      operationId: findTeam
+      responses:
+        "200":
+          description: team response
+          schema:
+            type: object
+            items:
+              $ref: '#/definitions/Team'
+          examples:
+            application/json:
+              id: 10
+              name: Engineering
+
+definitions:
+  Team:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: string
+      name:
+        type: string

--- a/plugin/openapi/src/test/resources/config/openapi-plugin-objects-config.json
+++ b/plugin/openapi/src/test/resources/config/openapi-plugin-objects-config.json
@@ -1,0 +1,4 @@
+{
+  "plugin": "com.gatehill.imposter.plugin.openapi.OpenApiPluginImpl",
+  "specFile": "object-examples.yaml"
+}


### PR DESCRIPTION
Adds support for response examples defined as objects, for example an API specification like `plugin/openapi/src/test/resources/config/object-examples.yaml`

The salient part of the response is as follows:

```yaml
responses:
  "200":
    description: team response
    schema:
      type: object
      items:
        $ref: '#/definitions/Team'
    examples:
      application/json:
        id: 10
        name: Engineering
```

> Note: the JSON example is specified as an object.

This currently supports JSON and YAML serialised content types in the response if they are specified in this way. If you want to return a different format, return a literal string, such as those above.
