### PR TITLE
Bump swagger parser version to '2.0.21' and fix the example collection for date and date-time schemas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
         version_groovy = '2.4.12'
         version_args4j = '2.33'
         version_jackson = '2.9.9'
-        version_swaggerParser = '2.0.13'
+        version_swaggerParser = '2.0.21'
     }
 }
 

--- a/plugin/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/service/SchemaServiceImpl.java
+++ b/plugin/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/service/SchemaServiceImpl.java
@@ -3,17 +3,14 @@ package io.gatehill.imposter.plugin.openapi.service;
 import io.gatehill.imposter.plugin.openapi.model.ContentTypedHolder;
 import io.gatehill.imposter.plugin.openapi.util.RefUtil;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.media.ArraySchema;
-import io.swagger.v3.oas.models.media.ComposedSchema;
-import io.swagger.v3.oas.models.media.ObjectSchema;
-import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.text.SimpleDateFormat;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.nonNull;
@@ -26,6 +23,7 @@ import static java.util.Objects.nonNull;
  */
 public class SchemaServiceImpl implements SchemaService {
     private static final Logger LOGGER = LogManager.getLogger(SchemaServiceImpl.class);
+    private static final SimpleDateFormat ISO_FULL_DATE = new SimpleDateFormat("yyyy-MM-dd");
 
     @Override
     public ContentTypedHolder<?> collectExamples(OpenAPI spec, ContentTypedHolder<Schema<?>> schema) {
@@ -47,7 +45,13 @@ public class SchemaServiceImpl implements SchemaService {
             example = collectSchemaExample(spec, referent);
 
         } else if (nonNull(schema.getExample())) {
-            example = schema.getExample();
+            if (schema instanceof DateTimeSchema) {
+                example = ((OffsetDateTime) schema.getExample()).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+            } else if (schema instanceof DateSchema) {
+                example = ISO_FULL_DATE.format(((Date) schema.getExample()));
+            } else {
+                example = schema.getExample();
+            }
 
         } else if (nonNull(schema.getProperties())) {
             example = buildFromProperties(spec, schema.getProperties());

--- a/plugin/openapi/src/test/groovy/io/gatehill/imposter/plugin/openapi/SchemaExamplesTest.groovy
+++ b/plugin/openapi/src/test/groovy/io/gatehill/imposter/plugin/openapi/SchemaExamplesTest.groovy
@@ -59,6 +59,8 @@ class SchemaExamplesTest extends BaseVerticleTest {
                 "name": "",
                 "id": 0,
                 "breed": "Collie",
+                "bornAt" : "2015-02-01T08:00:00Z",
+                "lastVetVisitAt": "2020-03-15",
                 "misc": {
                     "nocturnal": false,
                     "population": 47435
@@ -89,6 +91,8 @@ class SchemaExamplesTest extends BaseVerticleTest {
         testContext.assertEquals("", first.get("name"));
         testContext.assertEquals(0, first.get("id"));
         testContext.assertEquals("Collie", first.get("breed"));
+        testContext.assertEquals("2015-02-01T08:00:00Z", first.get("bornAt"));
+        testContext.assertEquals("2020-03-15", first.get("lastVetVisitAt"));
 
         final misc = first.get("misc") as Map<String, ?>
         testContext.assertNotNull(misc, "misc property should not be null");

--- a/plugin/openapi/src/test/resources/openapi2/model-examples/model-examples.yaml
+++ b/plugin/openapi/src/test/resources/openapi2/model-examples/model-examples.yaml
@@ -48,6 +48,14 @@ definitions:
       breed:
         type: string
         example: Collie
+      bornAt:
+        type: string
+        format: date-time
+        example: "2015-02-01T08:00:00Z"
+      lastVetVisitAt:
+        type: string
+        format: date
+        example: "2020-03-15"
       misc:
         type: object
         properties:


### PR DESCRIPTION
After wondering why my date and date-time examples were not reflected in the mock response I found out that the old swagger parser did not parse these examples.

Bumping the parser version to 2.0.21 fixed this behaviour so that the examples can now be returned in the mock response.
The parser converts the date-time example to a OffsetDateTime and a date example as Date which need to be formatted as Strings (I don't know why the parser mixes old a new date time types).

@outofcoffee Could you please have a look at my changes and consider merging them? Any feedback is welcome. This is my first open source pull request so there might still be room for improvement.