### PR TITLE
Fix for parseOptions.resolveFully in openapi plugin

### DIFF
--- a/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/service/SpecificationLoaderService.kt
+++ b/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/service/SpecificationLoaderService.kt
@@ -91,7 +91,7 @@ class SpecificationLoaderService @Inject constructor(
         logger.trace("Using version: {} parser for: {}", specVersion, specFile)
 
         val parseOptions = ParseOptions()
-        parseOptions.isResolveFully = true
+        parseOptions.setResolveFully(true)
 
         // convert or parse directly
         val parseResult: SwaggerParseResult? = when (specVersion) {


### PR DESCRIPTION
Fix for remote ref files in openapi plugin

[https://github.com/outofcoffee/imposter/issues/145](https://github.com/outofcoffee/imposter/issues/145)