### PR TITLE
docker container cannot load OpenAPI spec $ref correctly

### DIFF
--- a/distro/openapi/Dockerfile
+++ b/distro/openapi/Dockerfile
@@ -4,4 +4,6 @@ FROM outofcoffee/imposter-base:${BASE_IMAGE_TAG}
 
 LABEL MAINTAINER="Pete Cornish <outofcoffee@gmail.com>"
 
+WORKDIR /opt/imposter/config
+
 CMD ["--plugin", "openapi", "--configDir", "/opt/imposter/config"]


### PR DESCRIPTION
Changed working directory to /opt/imposter/config so the swagger library can load $ref correctly

The Swagger library will load the $ref in the directory it is running. Current docker configuration cannot load the $ref properly unless you specific the WORKDIR to /opt/imposter/config.

Another solution is update the code in https://github.com/outofcoffee/imposter/blob/main/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/service/SpecificationLoaderService.kt#L99 to include location, however it is only work for openapi but not swagger.