### PR TITLE
refactor: makes route handlers asynchronous

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
           echo "EFFECTIVE_BRANCH=${EFFECTIVE_BRANCH_NAME}" >> $GITHUB_OUTPUT
 
       - name: Test
-        run: ./gradlew test --info --stacktrace
+        run: ./gradlew test --stacktrace
 
       - name: Publish Unit Test Results
         if: always()
@@ -67,7 +67,7 @@ jobs:
           check_name: Unit Tests (Java ${{ matrix.java }})
 
       - name: Build distributions
-        run: ./gradlew dist --info --stacktrace
+        run: ./gradlew dist --stacktrace
 
       - name: Integration test
         run: |

--- a/adapter/awslambda/src/main/java/io/gatehill/imposter/awslambda/impl/LambdaServer.kt
+++ b/adapter/awslambda/src/main/java/io/gatehill/imposter/awslambda/impl/LambdaServer.kt
@@ -90,7 +90,7 @@ abstract class LambdaServer<Request, Response>(
                     val exchange = LambdaHttpExchange(router, route, request, response)
                     val handler = route.handler ?: throw IllegalStateException("No route handler set for: $route")
                     try {
-                        handler(exchange)
+                        handler(exchange).get()
                     } catch (e: Exception) {
                         throw RuntimeException("Unhandled error in route: $route", e)
                     }

--- a/adapter/awslambda/src/main/java/io/gatehill/imposter/awslambda/impl/LambdaServerFactory.kt
+++ b/adapter/awslambda/src/main/java/io/gatehill/imposter/awslambda/impl/LambdaServerFactory.kt
@@ -53,6 +53,7 @@ import io.gatehill.imposter.server.HttpServer
 import io.gatehill.imposter.server.ServerFactory
 import io.gatehill.imposter.service.ResponseFileService
 import io.gatehill.imposter.service.ResponseService
+import io.gatehill.imposter.util.completedUnitFuture
 import io.gatehill.imposter.util.makeFuture
 import io.vertx.core.Vertx
 import io.vertx.core.http.impl.HttpUtils
@@ -82,9 +83,7 @@ class LambdaServerFactory @Inject constructor(
         return CompletableFuture.completedFuture(activeServer)
     }
 
-    override fun createBodyHttpHandler(): HttpExchangeFutureHandler = {
-        CompletableFuture.completedFuture(Unit)
-    }
+    override fun createBodyHttpHandler(): HttpExchangeFutureHandler = { completedUnitFuture() }
 
     override fun createStaticHttpHandler(root: String, relative: Boolean): HttpExchangeFutureHandler {
         val pluginConfig = PluginConfigImpl().apply {
@@ -114,9 +113,7 @@ class LambdaServerFactory @Inject constructor(
         }
     }
 
-    override fun createMetricsHandler(): HttpExchangeFutureHandler = {
-        CompletableFuture.completedFuture(Unit)
-    }
+    override fun createMetricsHandler(): HttpExchangeFutureHandler = { completedUnitFuture() }
 
     companion object {
         private const val indexFile = "index.html"

--- a/core/api/src/main/java/io/gatehill/imposter/server/ServerFactory.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/server/ServerFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2024.
  *
  * This file is part of Imposter.
  *
@@ -44,7 +44,7 @@ package io.gatehill.imposter.server
 
 import com.google.inject.Injector
 import io.gatehill.imposter.ImposterConfig
-import io.gatehill.imposter.http.HttpExchangeHandler
+import io.gatehill.imposter.http.HttpExchangeFutureHandler
 import io.gatehill.imposter.http.HttpRouter
 import io.vertx.core.Vertx
 import java.util.concurrent.CompletableFuture
@@ -63,9 +63,9 @@ interface ServerFactory {
      */
     fun provide(injector: Injector, imposterConfig: ImposterConfig, vertx: Vertx, router: HttpRouter): CompletableFuture<HttpServer>
 
-    fun createBodyHttpHandler(): HttpExchangeHandler
+    fun createBodyHttpHandler(): HttpExchangeFutureHandler
 
-    fun createStaticHttpHandler(root: String, relative: Boolean = true): HttpExchangeHandler
+    fun createStaticHttpHandler(root: String, relative: Boolean = true): HttpExchangeFutureHandler
 
-    fun createMetricsHandler(): HttpExchangeHandler
+    fun createMetricsHandler(): HttpExchangeFutureHandler
 }

--- a/core/api/src/main/java/io/gatehill/imposter/service/ResourceService.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/service/ResourceService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023.
+ * Copyright (c) 2016-2024.
  *
  * This file is part of Imposter.
  *
@@ -45,6 +45,7 @@ package io.gatehill.imposter.service
 import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.config.ResolvedResourceConfig
 import io.gatehill.imposter.http.HttpExchange
+import io.gatehill.imposter.http.HttpExchangeFutureHandler
 import io.gatehill.imposter.http.HttpExchangeHandler
 import io.gatehill.imposter.http.HttpRouter
 import io.gatehill.imposter.http.ResourceMatcher
@@ -90,7 +91,7 @@ interface ResourceService {
         allPluginConfigs: List<PluginConfig>,
         resourceMatcher: ResourceMatcher,
         httpExchangeHandler: HttpExchangeHandler,
-    ): HttpExchangeHandler
+    ): HttpExchangeFutureHandler
 
     /**
      * Builds a handler that processes a request.
@@ -119,14 +120,14 @@ interface ResourceService {
         pluginConfig: PluginConfig,
         resourceMatcher: ResourceMatcher,
         httpExchangeHandler: HttpExchangeHandler,
-    ): HttpExchangeHandler
+    ): HttpExchangeFutureHandler
 
     fun passthroughRoute(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>,
         resourceMatcher: ResourceMatcher,
-        httpExchangeHandler: HttpExchangeHandler,
-    ): HttpExchangeHandler
+        httpExchangeHandler: HttpExchangeFutureHandler,
+    ): HttpExchangeFutureHandler
 
     /**
      * Catches 404 responses.

--- a/core/api/src/main/java/io/gatehill/imposter/service/ResourceService.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/service/ResourceService.kt
@@ -90,6 +90,16 @@ interface ResourceService {
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>,
         resourceMatcher: ResourceMatcher,
+        httpExchangeHandler: HttpExchangeFutureHandler,
+    ): HttpExchangeFutureHandler
+
+    /**
+     * Same as [handleRoute] but wraps [httpExchangeHandler] in a future.
+     */
+    fun handleRouteAndWrap(
+        imposterConfig: ImposterConfig,
+        allPluginConfigs: List<PluginConfig>,
+        resourceMatcher: ResourceMatcher,
         httpExchangeHandler: HttpExchangeHandler,
     ): HttpExchangeFutureHandler
 
@@ -116,6 +126,16 @@ interface ResourceService {
      * @return the handler
      */
     fun handleRoute(
+        imposterConfig: ImposterConfig,
+        pluginConfig: PluginConfig,
+        resourceMatcher: ResourceMatcher,
+        httpExchangeHandler: HttpExchangeFutureHandler,
+    ): HttpExchangeFutureHandler
+
+    /**
+     * Same as [handleRoute] but wraps [httpExchangeHandler] in a future.
+     */
+    fun handleRouteAndWrap(
         imposterConfig: ImposterConfig,
         pluginConfig: PluginConfig,
         resourceMatcher: ResourceMatcher,

--- a/core/api/src/main/java/io/gatehill/imposter/service/ResponseRoutingService.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/service/ResponseRoutingService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2024.
  *
  * This file is part of Imposter.
  *
@@ -51,7 +51,9 @@ import io.gatehill.imposter.plugin.config.PluginConfig
 import io.gatehill.imposter.plugin.config.PluginConfigImpl
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.script.ResponseBehaviour
-import java.util.function.Consumer
+import java.util.concurrent.CompletableFuture
+
+typealias DefaultBehaviourHandler = (ResponseBehaviour) -> Unit
 
 /**
  * Main entrypoint for response routing.
@@ -71,14 +73,14 @@ interface ResponseRoutingService {
         additionalContext: Map<String, Any>?,
         statusCodeFactory: StatusCodeFactory,
         responseBehaviourFactory: ResponseBehaviourFactory,
-        defaultBehaviourHandler: Consumer<ResponseBehaviour>
-    )
+        defaultBehaviourHandler: DefaultBehaviourHandler
+    ): CompletableFuture<Unit>
 
     fun <C : PluginConfigImpl> route(
         pluginConfig: C,
         httpExchange: HttpExchange,
-        defaultBehaviourHandler: Consumer<ResponseBehaviour>
-    ) {
+        defaultBehaviourHandler: DefaultBehaviourHandler
+    ): CompletableFuture<Unit> =
         route(
             pluginConfig,
             pluginConfig,
@@ -88,14 +90,13 @@ interface ResponseRoutingService {
             DefaultResponseBehaviourFactory.instance,
             defaultBehaviourHandler
         )
-    }
 
     fun <C : PluginConfigImpl> route(
         pluginConfig: C,
         resourceConfig: BasicResourceConfig?,
         httpExchange: HttpExchange,
-        defaultBehaviourHandler: Consumer<ResponseBehaviour>
-    ) {
+        defaultBehaviourHandler: DefaultBehaviourHandler
+    ): CompletableFuture<Unit> =
         route(
             pluginConfig,
             resourceConfig,
@@ -105,14 +106,13 @@ interface ResponseRoutingService {
             DefaultResponseBehaviourFactory.instance,
             defaultBehaviourHandler
         )
-    }
 
     fun <C : PluginConfigImpl> route(
         pluginConfig: C,
         httpExchange: HttpExchange,
         additionalContext: Map<String, Any>?,
-        defaultBehaviourHandler: Consumer<ResponseBehaviour>
-    ) {
+        defaultBehaviourHandler: DefaultBehaviourHandler
+    ): CompletableFuture<Unit> =
         route(
             pluginConfig,
             pluginConfig,
@@ -122,5 +122,4 @@ interface ResponseRoutingService {
             DefaultResponseBehaviourFactory.instance,
             defaultBehaviourHandler
         )
-    }
 }

--- a/core/api/src/main/java/io/gatehill/imposter/service/ResponseRoutingService.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/service/ResponseRoutingService.kt
@@ -53,7 +53,7 @@ import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.script.ResponseBehaviour
 import java.util.concurrent.CompletableFuture
 
-typealias DefaultBehaviourHandler = (ResponseBehaviour) -> Unit
+typealias DefaultBehaviourHandler = (ResponseBehaviour) -> CompletableFuture<Unit>
 
 /**
  * Main entrypoint for response routing.

--- a/core/api/src/main/java/io/gatehill/imposter/service/ResponseService.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/service/ResponseService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023.
+ * Copyright (c) 2016-2024.
  *
  * This file is part of Imposter.
  *
@@ -48,6 +48,7 @@ import io.gatehill.imposter.plugin.config.PluginConfig
 import io.gatehill.imposter.plugin.config.resource.ResourceConfig
 import io.gatehill.imposter.script.ResponseBehaviour
 import io.vertx.core.buffer.Buffer
+import java.util.concurrent.CompletableFuture
 
 /**
  * @author Pete Cornish
@@ -77,7 +78,7 @@ interface ResponseService {
         resourceConfig: ResourceConfig?,
         httpExchange: HttpExchange,
         responseBehaviour: ResponseBehaviour,
-    )
+    ): CompletableFuture<Unit>
 
     /**
      * Send a response to the client, if one can be computed. If a response cannot
@@ -95,7 +96,7 @@ interface ResponseService {
         httpExchange: HttpExchange,
         responseBehaviour: ResponseBehaviour,
         vararg fallbackSenders: ResponseSender,
-    )
+    ): CompletableFuture<Unit>
 
     /**
      * Fails the [HttpExchange] with a 404, triggering the configured error handler.

--- a/core/engine/src/main/java/io/gatehill/imposter/Imposter.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/Imposter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023.
+ * Copyright (c) 2016-2024.
  *
  * This file is part of Imposter.
  *
@@ -210,7 +210,7 @@ class Imposter(
 
         // status check to indicate when server is up
         router.get("/system/status").handler(
-            resourceService.handleRoute(imposterConfig, allConfigs, resourceMatcher) { httpExchange ->
+            resourceService.handleRouteAndWrap(imposterConfig, allConfigs, resourceMatcher) { httpExchange ->
                 httpExchange.response
                     .putHeader(HttpUtil.CONTENT_TYPE, HttpUtil.CONTENT_TYPE_JSON)
                     .end(HttpUtil.buildStatusResponse())

--- a/core/engine/src/main/java/io/gatehill/imposter/service/ResourceServiceImpl.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/service/ResourceServiceImpl.kt
@@ -142,7 +142,7 @@ class ResourceServiceImpl @Inject constructor(
             }
 
             RequestHandlingMode.ASYNC -> { httpExchange: HttpExchange ->
-                makeFuture { future ->
+                makeFuture(autoComplete = false) { future ->
                     val handler = Callable {
                         handleResource(pluginConfig, httpExchangeHandler, httpExchange, resolvedResourceConfigs, resourceMatcher)
                             .thenApply { future.complete(it) }

--- a/core/engine/src/main/java/io/gatehill/imposter/service/ResponseRoutingServiceImpl.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/service/ResponseRoutingServiceImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023.
+ * Copyright (c) 2016-2024.
  *
  * This file is part of Imposter.
  *
@@ -55,8 +55,9 @@ import io.gatehill.imposter.script.ReadWriteResponseBehaviour
 import io.gatehill.imposter.script.ResponseBehaviour
 import io.gatehill.imposter.script.ResponseBehaviourType
 import io.gatehill.imposter.util.LogUtil
+import io.gatehill.imposter.util.makeFuture
 import org.apache.logging.log4j.LogManager
-import java.util.function.Consumer
+import java.util.concurrent.CompletableFuture
 import javax.inject.Inject
 
 /**
@@ -80,8 +81,8 @@ class ResponseRoutingServiceImpl @Inject constructor(
         additionalContext: Map<String, Any>?,
         statusCodeFactory: StatusCodeFactory,
         responseBehaviourFactory: ResponseBehaviourFactory,
-        defaultBehaviourHandler: Consumer<ResponseBehaviour>,
-    ) {
+        defaultBehaviourHandler: DefaultBehaviourHandler,
+    ): CompletableFuture<Unit> = makeFuture {
         try {
             engineLifecycle.forEach { listener: EngineLifecycleListener ->
                 listener.beforeBuildingResponse(httpExchange, resourceConfig)
@@ -100,7 +101,7 @@ class ResponseRoutingServiceImpl @Inject constructor(
                     .end()
             } else {
                 // default behaviour
-                defaultBehaviourHandler.accept(responseBehaviour)
+                defaultBehaviourHandler(responseBehaviour)
             }
         } catch (e: Exception) {
             val msg = "Error sending mock response for ${LogUtil.describeRequest(httpExchange)}"

--- a/core/engine/src/main/java/io/gatehill/imposter/service/ResponseServiceImpl.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/service/ResponseServiceImpl.kt
@@ -110,7 +110,7 @@ class ResponseServiceImpl @Inject constructor(
         httpExchange: HttpExchange,
         responseBehaviour: ResponseBehaviour,
         vararg fallbackSenders: ResponseSender,
-    ): CompletableFuture<Unit> = makeFuture { future ->
+    ): CompletableFuture<Unit> = makeFuture(autoComplete = false) { future ->
         val completion = {
             try {
                 responseBehaviour.failureType?.let { failureType ->

--- a/core/engine/src/main/java/io/gatehill/imposter/service/UpstreamService.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/service/UpstreamService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2023.
+ * Copyright (c) 2023-2024.
  *
  * This file is part of Imposter.
  *
@@ -50,12 +50,18 @@ import io.gatehill.imposter.plugin.config.resource.PassthroughResourceConfig
 import io.gatehill.imposter.plugin.config.resource.UpstreamsHolder
 import io.gatehill.imposter.util.HttpUtil
 import io.gatehill.imposter.util.LogUtil
+import io.gatehill.imposter.util.makeFuture
 import io.vertx.core.buffer.Buffer
-import okhttp3.*
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
 import org.apache.logging.log4j.LogManager
 import java.io.IOException
 import java.net.URI
+import java.util.concurrent.CompletableFuture
 import javax.inject.Inject
 
 /**
@@ -73,7 +79,7 @@ class UpstreamService @Inject constructor(
         pluginConfig: UpstreamsHolder,
         resourceConfig: PassthroughResourceConfig,
         httpExchange: HttpExchange,
-    ) {
+    ): CompletableFuture<Unit> = makeFuture {
         logger.info("Forwarding request ${LogUtil.describeRequest(httpExchange)} to upstream ${resourceConfig.passthrough}")
         val call = buildCall(pluginConfig, resourceConfig, httpExchange)
         if (logger.isTraceEnabled) {

--- a/core/engine/src/main/java/io/gatehill/imposter/service/security/CorsService.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/service/security/CorsService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023.
+ * Copyright (c) 2023-2024.
  *
  * This file is part of Imposter.
  *
@@ -44,7 +44,12 @@
 package io.gatehill.imposter.service.security
 
 import io.gatehill.imposter.ImposterConfig
-import io.gatehill.imposter.http.*
+import io.gatehill.imposter.http.HttpExchange
+import io.gatehill.imposter.http.HttpExchangeFutureHandler
+import io.gatehill.imposter.http.HttpMethod
+import io.gatehill.imposter.http.HttpRequest
+import io.gatehill.imposter.http.HttpRouter
+import io.gatehill.imposter.http.ResourceMatcher
 import io.gatehill.imposter.plugin.config.PluginConfig
 import io.gatehill.imposter.plugin.config.security.CorsConfig
 import io.gatehill.imposter.plugin.config.security.CorsConfigHolder
@@ -96,7 +101,7 @@ class CorsService @Inject constructor(
         selectedConfig: PluginConfig,
         resourceMatcher: ResourceMatcher,
         cors: CorsConfig,
-    ): HttpExchangeHandler {
+    ): HttpExchangeFutureHandler {
         return resourceService.handleRoute(imposterConfig, selectedConfig, resourceMatcher) { exchange: HttpExchange ->
             val origin = determineResponseOrigin(cors, exchange.request)
             origin?.let {

--- a/core/engine/src/main/java/io/gatehill/imposter/service/security/CorsService.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/service/security/CorsService.kt
@@ -102,7 +102,7 @@ class CorsService @Inject constructor(
         resourceMatcher: ResourceMatcher,
         cors: CorsConfig,
     ): HttpExchangeFutureHandler {
-        return resourceService.handleRoute(imposterConfig, selectedConfig, resourceMatcher) { exchange: HttpExchange ->
+        return resourceService.handleRouteAndWrap(imposterConfig, selectedConfig, resourceMatcher) { exchange: HttpExchange ->
             val origin = determineResponseOrigin(cors, exchange.request)
             origin?.let {
                 logger.debug("Serving CORS pre-flight request: ${LogUtil.describeRequest(exchange)}")

--- a/core/engine/src/main/java/io/gatehill/imposter/util/Globals.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/util/Globals.kt
@@ -60,11 +60,17 @@ fun getJvmVersion(): Int {
     return version.toInt()
 }
 
-fun <T>makeFuture(block: (CompletableFuture<T>) -> T): CompletableFuture<T> {
+/**
+ * Wraps the given [block] in a `CompletableFuture` and returns the future.
+ * If [autoComplete] is `true`, the future will be completed with the result of the block.
+ * If [autoComplete] is `false`, the future must be completed manually by the block code.
+ * This is useful for long-running tasks that need to be managed externally.
+ */
+fun <T>makeFuture(autoComplete: Boolean = true, block: (CompletableFuture<T>) -> T): CompletableFuture<T> {
     val future = CompletableFuture<T>()
     try {
         val ret = block(future)
-        if (!future.isDone) {
+        if (autoComplete) {
             future.complete(ret)
         }
     } catch (e: Exception) {

--- a/core/engine/src/main/java/io/gatehill/imposter/util/Globals.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/util/Globals.kt
@@ -73,5 +73,7 @@ fun <T>makeFuture(block: (CompletableFuture<T>) -> T): CompletableFuture<T> {
     return future
 }
 
+fun completedUnitFuture(): CompletableFuture<Unit> = CompletableFuture.completedFuture(Unit)
+
 val supervisedDefaultCoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 val supervisedIOCoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())

--- a/core/engine/src/main/java/io/gatehill/imposter/util/Globals.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/util/Globals.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2016-2024.
  *
  * This file is part of Imposter.
  *
@@ -45,6 +45,7 @@ package io.gatehill.imposter.util
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import java.util.concurrent.CompletableFuture
 
 fun getJvmVersion(): Int {
     var version = System.getProperty("java.version")
@@ -57,6 +58,19 @@ fun getJvmVersion(): Int {
         }
     }
     return version.toInt()
+}
+
+fun <T>makeFuture(block: (CompletableFuture<T>) -> T): CompletableFuture<T> {
+    val future = CompletableFuture<T>()
+    try {
+        val ret = block(future)
+        if (!future.isDone) {
+            future.complete(ret)
+        }
+    } catch (e: Exception) {
+        future.completeExceptionally(e)
+    }
+    return future
 }
 
 val supervisedDefaultCoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())

--- a/core/http/src/main/java/io/gatehill/imposter/http/HttpRoute.kt
+++ b/core/http/src/main/java/io/gatehill/imposter/http/HttpRoute.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023.
+ * Copyright (c) 2022-2024.
  *
  * This file is part of Imposter.
  *
@@ -54,7 +54,7 @@ data class HttpRoute(
     val method: HttpMethod? = null
 ) {
     val hasTrailingWildcard = path?.endsWith('*') ?: false
-    var handler: HttpExchangeHandler? = null
+    var handler: HttpExchangeFutureHandler? = null
 
     private data class ParsedPathParams(
         val paramNames: List<String>,
@@ -81,7 +81,7 @@ data class HttpRoute(
 
     private val regexPattern: Pattern by lazy { Pattern.compile(regex!!) }
 
-    fun handler(requestHandler: HttpExchangeHandler): HttpRoute {
+    fun handler(requestHandler: HttpExchangeFutureHandler): HttpRoute {
         handler = requestHandler
         return this
     }

--- a/core/http/src/main/java/io/gatehill/imposter/http/HttpRouter.kt
+++ b/core/http/src/main/java/io/gatehill/imposter/http/HttpRouter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023.
+ * Copyright (c) 2016-2024.
  *
  * This file is part of Imposter.
  *
@@ -43,6 +43,7 @@
 package io.gatehill.imposter.http
 
 import io.vertx.core.Vertx
+import java.util.concurrent.CompletableFuture
 
 /**
  * @author Pete Cornish
@@ -141,3 +142,4 @@ class HttpRouter(val vertx: Vertx) {
 }
 
 typealias HttpExchangeHandler = (HttpExchange) -> Unit
+typealias HttpExchangeFutureHandler = (HttpExchange) -> CompletableFuture<Unit>

--- a/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/OpenApiPluginImpl.kt
+++ b/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/OpenApiPluginImpl.kt
@@ -44,7 +44,7 @@ package io.gatehill.imposter.plugin.openapi
 
 import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.http.HttpExchange
-import io.gatehill.imposter.http.HttpExchangeHandler
+import io.gatehill.imposter.http.HttpExchangeFutureHandler
 import io.gatehill.imposter.http.HttpMethod
 import io.gatehill.imposter.http.HttpRouter
 import io.gatehill.imposter.http.SingletonResourceMatcher
@@ -62,6 +62,7 @@ import io.gatehill.imposter.plugin.openapi.service.SpecificationLoaderService
 import io.gatehill.imposter.plugin.openapi.service.SpecificationService
 import io.gatehill.imposter.script.ResponseBehaviour
 import io.gatehill.imposter.server.ServerFactory
+import io.gatehill.imposter.service.DefaultBehaviourHandler
 import io.gatehill.imposter.service.ResourceService
 import io.gatehill.imposter.service.ResponseRoutingService
 import io.gatehill.imposter.service.ResponseService
@@ -287,7 +288,7 @@ class OpenApiPluginImpl @Inject constructor(
         pluginConfig: OpenApiPluginConfig,
         operation: Operation,
         spec: OpenAPI
-    ): HttpExchangeHandler {
+    ): HttpExchangeFutureHandler {
         // statically calculate as much as possible
         val statusCodeFactory = buildStatusCodeCalculator(operation)
         return resourceService.handleRoute(imposterConfig, pluginConfig, resourceMatcher) { httpExchange: HttpExchange ->
@@ -302,7 +303,7 @@ class OpenApiPluginImpl @Inject constructor(
 
             val resourceConfig = httpExchange.get<BasicResourceConfig>(ResourceUtil.RESOURCE_CONFIG_KEY)
 
-            val defaultBehaviourHandler = { responseBehaviour: ResponseBehaviour ->
+            val defaultBehaviourHandler: DefaultBehaviourHandler = { responseBehaviour: ResponseBehaviour ->
                 // set status code regardless of response strategy
                 val response = httpExchange.response.setStatusCode(responseBehaviour.statusCode)
 

--- a/mock/rest/src/main/java/io/gatehill/imposter/plugin/rest/RestPluginImpl.kt
+++ b/mock/rest/src/main/java/io/gatehill/imposter/plugin/rest/RestPluginImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023.
+ * Copyright (c) 2016-2024.
  *
  * This file is part of Imposter.
  *
@@ -43,7 +43,11 @@
 package io.gatehill.imposter.plugin.rest
 
 import io.gatehill.imposter.ImposterConfig
-import io.gatehill.imposter.http.*
+import io.gatehill.imposter.http.HttpExchange
+import io.gatehill.imposter.http.HttpMethod
+import io.gatehill.imposter.http.HttpRouter
+import io.gatehill.imposter.http.SingletonResourceMatcher
+import io.gatehill.imposter.http.UniqueRoute
 import io.gatehill.imposter.plugin.PluginInfo
 import io.gatehill.imposter.plugin.config.ConfiguredPlugin
 import io.gatehill.imposter.plugin.config.ContentTypedConfig
@@ -59,8 +63,10 @@ import io.gatehill.imposter.util.FileUtil.findRow
 import io.gatehill.imposter.util.HttpUtil
 import io.gatehill.imposter.util.LogUtil
 import io.gatehill.imposter.util.ResourceUtil
+import io.gatehill.imposter.util.makeFuture
 import io.vertx.core.Vertx
 import org.apache.logging.log4j.LogManager
+import java.util.concurrent.CompletableFuture
 import java.util.regex.Pattern
 import javax.inject.Inject
 
@@ -143,12 +149,12 @@ open class RestPluginImpl @Inject constructor(
         resourceConfig: ContentTypedConfig,
         httpExchange: HttpExchange,
         responseBehaviour: ResponseBehaviour,
-    ) {
+    ): CompletableFuture<Unit> {
         LOGGER.info(
             "Handling object request for: {}",
             LogUtil.describeRequestShort(httpExchange)
         )
-        responseService.sendResponse(pluginConfig, resourceConfig, httpExchange, responseBehaviour)
+        return responseService.sendResponse(pluginConfig, resourceConfig, httpExchange, responseBehaviour)
     }
 
     private fun handleArray(
@@ -156,7 +162,7 @@ open class RestPluginImpl @Inject constructor(
         resourceConfig: ContentTypedConfig,
         httpExchange: HttpExchange,
         responseBehaviour: ResponseBehaviour,
-    ) {
+    ): CompletableFuture<Unit> = makeFuture {
         // validate path includes parameter
         val resourcePath = resourceConfig.path ?: ""
         val matcher = PARAM_MATCHER.matcher(resourcePath)

--- a/mock/sfdc/src/main/java/io/gatehill/imposter/plugin/sfdc/SfdcPluginImpl.kt
+++ b/mock/sfdc/src/main/java/io/gatehill/imposter/plugin/sfdc/SfdcPluginImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023.
+ * Copyright (c) 2016-2024.
  *
  * This file is part of Imposter.
  *
@@ -44,7 +44,7 @@ package io.gatehill.imposter.plugin.sfdc
 
 import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.http.HttpExchange
-import io.gatehill.imposter.http.HttpExchangeHandler
+import io.gatehill.imposter.http.HttpExchangeFutureHandler
 import io.gatehill.imposter.http.HttpMethod
 import io.gatehill.imposter.http.HttpRouter
 import io.gatehill.imposter.http.SingletonResourceMatcher
@@ -198,7 +198,7 @@ class SfdcPluginImpl @Inject constructor(
      *
      * @return
      */
-    private fun handleUpdateRequest(): HttpExchangeHandler {
+    private fun handleUpdateRequest(): HttpExchangeFutureHandler {
         return resourceService.handleRoute(imposterConfig, configs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val sObjectName = request.getPathParam("sObjectName")

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/SoapPluginImpl.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/SoapPluginImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023.
+ * Copyright (c) 2016-2024.
  *
  * This file is part of Imposter.
  *
@@ -64,6 +64,7 @@ import io.gatehill.imposter.plugin.soap.parser.WsdlParser
 import io.gatehill.imposter.plugin.soap.service.SoapExampleService
 import io.gatehill.imposter.plugin.soap.util.SoapUtil
 import io.gatehill.imposter.script.ResponseBehaviour
+import io.gatehill.imposter.service.DefaultBehaviourHandler
 import io.gatehill.imposter.service.ResourceService
 import io.gatehill.imposter.service.ResponseRoutingService
 import io.gatehill.imposter.service.ResponseService
@@ -214,7 +215,7 @@ class SoapPluginImpl @Inject constructor(
         val responseBehaviourFactory = DefaultResponseBehaviourFactory.instance
         val resourceConfig = httpExchange.get<BasicResourceConfig>(ResourceUtil.RESOURCE_CONFIG_KEY)
 
-        val defaultBehaviourHandler = { responseBehaviour: ResponseBehaviour ->
+        val defaultBehaviourHandler: DefaultBehaviourHandler = { responseBehaviour: ResponseBehaviour ->
             // set status code regardless of response strategy
             val response = httpExchange.response
                 .setStatusCode(responseBehaviour.statusCode)

--- a/store/common/src/main/java/io/gatehill/imposter/store/service/StoreRestApiServiceImpl.kt
+++ b/store/common/src/main/java/io/gatehill/imposter/store/service/StoreRestApiServiceImpl.kt
@@ -94,12 +94,12 @@ class StoreRestApiServiceImpl @Inject constructor(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
     ): HttpExchangeFutureHandler {
-        return resourceService.handleRoute(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
+        return resourceService.handleRouteAndWrap(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
             val store = openStore(storeName)
             if (Objects.isNull(store)) {
-                return@handleRoute
+                return@handleRouteAndWrap
             }
 
             if (httpExchange.isAcceptHeaderEmpty() || httpExchange.acceptsMimeType(HttpUtil.CONTENT_TYPE_JSON)) {
@@ -127,7 +127,7 @@ class StoreRestApiServiceImpl @Inject constructor(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
     ): HttpExchangeFutureHandler {
-        return resourceService.handleRoute(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
+        return resourceService.handleRouteAndWrap(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val storeName = httpExchange.request.getPathParam("storeName")!!
             storeFactory.clearStore(storeName, ephemeral = false)
             LOGGER.debug("Deleted store: {}", storeName)
@@ -142,12 +142,12 @@ class StoreRestApiServiceImpl @Inject constructor(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
     ): HttpExchangeFutureHandler {
-        return resourceService.handleRoute(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
+        return resourceService.handleRouteAndWrap(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
             val store = openStore(storeName)
             if (Objects.isNull(store)) {
-                return@handleRoute
+                return@handleRouteAndWrap
             }
 
             val key = request.getPathParam("key")!!
@@ -175,12 +175,12 @@ class StoreRestApiServiceImpl @Inject constructor(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
     ): HttpExchangeFutureHandler {
-        return resourceService.handleRoute(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
+        return resourceService.handleRouteAndWrap(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
             val store = openStore(storeName)
             if (Objects.isNull(store)) {
-                return@handleRoute
+                return@handleRouteAndWrap
             }
             val key = request.getPathParam("key")!!
 
@@ -204,12 +204,12 @@ class StoreRestApiServiceImpl @Inject constructor(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
     ): HttpExchangeFutureHandler {
-        return resourceService.handleRoute(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
+        return resourceService.handleRouteAndWrap(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
             val store = openStore(storeName)
             if (Objects.isNull(store)) {
-                return@handleRoute
+                return@handleRouteAndWrap
             }
 
             val items = request.bodyAsJson
@@ -227,12 +227,12 @@ class StoreRestApiServiceImpl @Inject constructor(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
     ): HttpExchangeFutureHandler {
-        return resourceService.handleRoute(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
+        return resourceService.handleRouteAndWrap(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
             val store = openStore(storeName)
             if (Objects.isNull(store)) {
-                return@handleRoute
+                return@handleRouteAndWrap
             }
 
             val key = request.getPathParam("key")!!

--- a/store/common/src/main/java/io/gatehill/imposter/store/service/StoreRestApiServiceImpl.kt
+++ b/store/common/src/main/java/io/gatehill/imposter/store/service/StoreRestApiServiceImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023.
+ * Copyright (c) 2016-2024.
  *
  * This file is part of Imposter.
  *
@@ -45,7 +45,7 @@ package io.gatehill.imposter.store.service
 import com.fasterxml.jackson.core.JsonProcessingException
 import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.http.HttpExchange
-import io.gatehill.imposter.http.HttpExchangeHandler
+import io.gatehill.imposter.http.HttpExchangeFutureHandler
 import io.gatehill.imposter.http.HttpRouter
 import io.gatehill.imposter.http.SingletonResourceMatcher
 import io.gatehill.imposter.lifecycle.EngineLifecycleHooks
@@ -93,7 +93,7 @@ class StoreRestApiServiceImpl @Inject constructor(
     private fun handleLoadAll(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
-    ): HttpExchangeHandler {
+    ): HttpExchangeFutureHandler {
         return resourceService.handleRoute(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
@@ -126,7 +126,7 @@ class StoreRestApiServiceImpl @Inject constructor(
     private fun handleDeleteStore(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
-    ): HttpExchangeHandler {
+    ): HttpExchangeFutureHandler {
         return resourceService.handleRoute(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val storeName = httpExchange.request.getPathParam("storeName")!!
             storeFactory.clearStore(storeName, ephemeral = false)
@@ -141,7 +141,7 @@ class StoreRestApiServiceImpl @Inject constructor(
     private fun handleLoadSingle(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
-    ): HttpExchangeHandler {
+    ): HttpExchangeFutureHandler {
         return resourceService.handleRoute(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
@@ -174,7 +174,7 @@ class StoreRestApiServiceImpl @Inject constructor(
     private fun handleSaveSingle(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
-    ): HttpExchangeHandler {
+    ): HttpExchangeFutureHandler {
         return resourceService.handleRoute(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
@@ -203,7 +203,7 @@ class StoreRestApiServiceImpl @Inject constructor(
     private fun handleSaveMultiple(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
-    ): HttpExchangeHandler {
+    ): HttpExchangeFutureHandler {
         return resourceService.handleRoute(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
@@ -226,7 +226,7 @@ class StoreRestApiServiceImpl @Inject constructor(
     private fun handleDeleteSingle(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
-    ): HttpExchangeHandler {
+    ): HttpExchangeFutureHandler {
         return resourceService.handleRoute(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!


### PR DESCRIPTION
All route handlers return `CompletableFuture<Unit>` instead of `Unit`.