### PR TITLE
fix: in SOAP plugin, support WSDL with XML schema include

### DIFF
--- a/mock/soap/build.gradle
+++ b/mock/soap/build.gradle
@@ -24,10 +24,6 @@ dependencies {
     testImplementation project(':test:sample-soap-client')
 }
 
-test {
-    forkEvery 1
-}
-
 task sourcesJar(type: Jar, dependsOn: classes) {
     archiveClassifier = 'sources'
     from sourceSets.main.allSource

--- a/mock/soap/build.gradle
+++ b/mock/soap/build.gradle
@@ -24,6 +24,10 @@ dependencies {
     testImplementation project(':test:sample-soap-client')
 }
 
+test {
+    forkEvery 1
+}
+
 task sourcesJar(type: Jar, dependsOn: classes) {
     archiveClassifier = 'sources'
     from sourceSets.main.allSource

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/AbstractWsdlParser.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/AbstractWsdlParser.kt
@@ -81,7 +81,7 @@ abstract class AbstractWsdlParser(
             SchemaDocument.Factory.parse(schemaFile, XmlOptions().setLoadLineNumbers().setLoadMessageDigest())
         }
 
-        logger.debug("Discovered ${schemas.size} schema(s) for WSDL: $wsdlFile")
+        logger.debug("Discovered {} schema(s) for WSDL: {}", schemas.size, wsdlFile)
         return schemas.toTypedArray()
     }
 
@@ -117,6 +117,7 @@ abstract class AbstractWsdlParser(
             throw IllegalStateException("Cannot build XSD from empty schema list")
         }
         val compileOptions = XmlOptions()
+            .setEntityResolver(WsdlRelativeXsdEntityResolver(wsdlFile.parentFile))
         try {
             return XmlBeans.compileXsd(schemas, XmlBeans.getBuiltinTypeSystem(), compileOptions)
         } catch (e: Exception) {

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/VersionAwareWsdlParser.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/VersionAwareWsdlParser.kt
@@ -62,9 +62,8 @@ class VersionAwareWsdlParser(wsdlFile: File) : WsdlParser {
     private val delegate: WsdlParser
 
     init {
-        val document = SAXBuilder().apply {
-            entityResolver = WsdlRelativeXsdEntityResolver(wsdlFile.parentFile)
-        }.build(wsdlFile)
+        val entityResolver = WsdlRelativeXsdEntityResolver(wsdlFile.parentFile)
+        val document = SAXBuilder().apply { setEntityResolver(entityResolver) }.build(wsdlFile)
 
         val wsdlNamespaces = document.rootElement.namespacesInScope.filter {
             it.uri == Wsdl2Parser.wsdl2Namespace || it.uri == Wsdl1Parser.wsdl1Namespace
@@ -72,8 +71,8 @@ class VersionAwareWsdlParser(wsdlFile: File) : WsdlParser {
         delegate = when (wsdlNamespaces.size) {
             0 -> throw IllegalStateException("No WSDL namespace found on root element")
             1 -> when (wsdlNamespaces.first().uri) {
-                Wsdl1Parser.wsdl1Namespace -> Wsdl1Parser(wsdlFile, document)
-                Wsdl2Parser.wsdl2Namespace -> Wsdl2Parser(wsdlFile, document)
+                Wsdl1Parser.wsdl1Namespace -> Wsdl1Parser(wsdlFile, document, entityResolver)
+                Wsdl2Parser.wsdl2Namespace -> Wsdl2Parser(wsdlFile, document, entityResolver)
                 else -> throw IllegalStateException("Unsupported WSDL namespace on root element")
             }
             else -> throw IllegalStateException("More than one WSDL namespace found on root element: $wsdlNamespaces")

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/VersionAwareWsdlParser.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/VersionAwareWsdlParser.kt
@@ -62,7 +62,10 @@ class VersionAwareWsdlParser(wsdlFile: File) : WsdlParser {
     private val delegate: WsdlParser
 
     init {
-        val document = SAXBuilder().build(wsdlFile)
+        val document = SAXBuilder().apply {
+            entityResolver = WsdlRelativeXsdEntityResolver(wsdlFile.parentFile)
+        }.build(wsdlFile)
+
         val wsdlNamespaces = document.rootElement.namespacesInScope.filter {
             it.uri == Wsdl2Parser.wsdl2Namespace || it.uri == Wsdl1Parser.wsdl1Namespace
         }
@@ -75,7 +78,7 @@ class VersionAwareWsdlParser(wsdlFile: File) : WsdlParser {
             }
             else -> throw IllegalStateException("More than one WSDL namespace found on root element: $wsdlNamespaces")
         }
-        logger.debug("Using WSDL parser: $version for: $wsdlFile")
+        logger.debug("Using WSDL parser: {} for: {}", version, wsdlFile)
     }
 
     override val version: WsdlParser.WsdlVersion

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Parser.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Parser.kt
@@ -43,12 +43,18 @@
 
 package io.gatehill.imposter.plugin.soap.parser
 
-import io.gatehill.imposter.plugin.soap.model.*
+import io.gatehill.imposter.plugin.soap.model.BindingType
+import io.gatehill.imposter.plugin.soap.model.WsdlBinding
+import io.gatehill.imposter.plugin.soap.model.WsdlEndpoint
+import io.gatehill.imposter.plugin.soap.model.WsdlInterface
+import io.gatehill.imposter.plugin.soap.model.WsdlOperation
+import io.gatehill.imposter.plugin.soap.model.WsdlService
 import io.gatehill.imposter.plugin.soap.util.SoapUtil
 import io.gatehill.imposter.util.BodyQueryUtil
 import org.jdom2.Document
 import org.jdom2.Element
 import org.jdom2.Namespace
+import org.xml.sax.EntityResolver
 import java.io.File
 import java.net.URI
 import javax.xml.namespace.QName
@@ -61,7 +67,8 @@ import javax.xml.namespace.QName
 class Wsdl1Parser(
     wsdlFile: File,
     document: Document,
-) : AbstractWsdlParser(wsdlFile, document) {
+    entityResolver: EntityResolver,
+) : AbstractWsdlParser(wsdlFile, document, entityResolver) {
 
     override val version = WsdlParser.WsdlVersion.V1
 

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/Wsdl2Parser.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/Wsdl2Parser.kt
@@ -43,11 +43,17 @@
 
 package io.gatehill.imposter.plugin.soap.parser
 
-import io.gatehill.imposter.plugin.soap.model.*
+import io.gatehill.imposter.plugin.soap.model.BindingType
+import io.gatehill.imposter.plugin.soap.model.WsdlBinding
+import io.gatehill.imposter.plugin.soap.model.WsdlEndpoint
+import io.gatehill.imposter.plugin.soap.model.WsdlInterface
+import io.gatehill.imposter.plugin.soap.model.WsdlOperation
+import io.gatehill.imposter.plugin.soap.model.WsdlService
 import io.gatehill.imposter.util.BodyQueryUtil
 import org.jdom2.Document
 import org.jdom2.Element
 import org.jdom2.Namespace
+import org.xml.sax.EntityResolver
 import java.io.File
 import java.net.URI
 import javax.xml.namespace.QName
@@ -59,8 +65,9 @@ import javax.xml.namespace.QName
  */
 class Wsdl2Parser(
     wsdlFile: File,
-    document: Document
-) : AbstractWsdlParser(wsdlFile, document) {
+    document: Document,
+    entityResolver: EntityResolver,
+) : AbstractWsdlParser(wsdlFile, document, entityResolver) {
 
     override val version = WsdlParser.WsdlVersion.V2
 

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/WsdlRelativeXsdEntityResolver.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/WsdlRelativeXsdEntityResolver.kt
@@ -24,6 +24,9 @@ class WsdlRelativeXsdEntityResolver(
         val xsdFile = File(wsdlDir.absoluteFile, systemId.replace("project://local/", ""))
         if (Files.isRegularFile(xsdFile.toPath()) && xsdFile.name.lowercase().endsWith(".xsd")) {
             logger.debug("Resolved XSD {} relative to WSDL path", xsdFile)
+
+            // according to the InputSource docs, the parser using this resolver
+            // should manage the clean-up of the stream.
             return InputSource(FileInputStream(xsdFile))
         }
         return null

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/WsdlRelativeXsdEntityResolver.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/WsdlRelativeXsdEntityResolver.kt
@@ -1,0 +1,36 @@
+package io.gatehill.imposter.plugin.soap.parser
+
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.xml.sax.EntityResolver
+import org.xml.sax.InputSource
+import java.io.File
+import java.io.FileInputStream
+import java.nio.file.Files
+
+/**
+ * EntityResolver to resolve XSDs included relative to the WSDL file.
+ */
+class WsdlRelativeXsdEntityResolver : EntityResolver {
+
+    companion object {
+        val wsdlFolderPathThreadLocal: ThreadLocal<String> = ThreadLocal()
+    }
+
+    private val logger: Logger = LogManager.getLogger(this::class.java)
+
+    override fun resolveEntity(publicId: String?, systemId: String?): InputSource? {
+        logger.trace("Resolve {} relative to path {}", systemId, wsdlFolderPathThreadLocal.get())
+        systemId ?: return null
+        val wsdlFolderPath = wsdlFolderPathThreadLocal.get() ?: return null;
+
+        // in certain occasions, XMLBeans prefixes the systemId (see StscState) -> strip it off
+        val xsdFile = File(wsdlFolderPath, systemId.replace("project://local/", ""))
+        if (Files.isRegularFile(xsdFile.toPath()) && xsdFile.name.lowercase().endsWith(".xsd")) {
+            logger.debug("Resolved XSD {} relative to WSDL path", xsdFile)
+            return InputSource(FileInputStream(xsdFile))
+        }
+        return null
+    }
+
+}

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/WsdlRelativeXsdEntityResolver.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/WsdlRelativeXsdEntityResolver.kt
@@ -11,26 +11,21 @@ import java.nio.file.Files
 /**
  * EntityResolver to resolve XSDs included relative to the WSDL file.
  */
-class WsdlRelativeXsdEntityResolver : EntityResolver {
-
-    companion object {
-        val wsdlFolderPathThreadLocal: ThreadLocal<String> = ThreadLocal()
-    }
-
+class WsdlRelativeXsdEntityResolver(
+    private val wsdlDir: File
+) : EntityResolver {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
     override fun resolveEntity(publicId: String?, systemId: String?): InputSource? {
-        logger.trace("Resolve {} relative to path {}", systemId, wsdlFolderPathThreadLocal.get())
+        logger.trace("Resolve {} relative to path {}", systemId, wsdlDir)
         systemId ?: return null
-        val wsdlFolderPath = wsdlFolderPathThreadLocal.get() ?: return null;
 
         // in certain occasions, XMLBeans prefixes the systemId (see StscState) -> strip it off
-        val xsdFile = File(wsdlFolderPath, systemId.replace("project://local/", ""))
+        val xsdFile = File(wsdlDir.absoluteFile, systemId.replace("project://local/", ""))
         if (Files.isRegularFile(xsdFile.toPath()) && xsdFile.name.lowercase().endsWith(".xsd")) {
             logger.debug("Resolved XSD {} relative to WSDL path", xsdFile)
             return InputSource(FileInputStream(xsdFile))
         }
         return null
     }
-
 }

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/service/SoapExampleService.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/service/SoapExampleService.kt
@@ -47,15 +47,25 @@ import io.gatehill.imposter.http.HttpExchange
 import io.gatehill.imposter.plugin.soap.model.MessageBodyHolder
 import io.gatehill.imposter.plugin.soap.model.ParsedRawBody
 import io.gatehill.imposter.plugin.soap.model.ParsedSoapMessage
+import io.gatehill.imposter.plugin.soap.parser.WsdlRelativeXsdEntityResolver
 import io.gatehill.imposter.plugin.soap.util.SoapUtil
 import io.gatehill.imposter.util.LogUtil
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import org.apache.xmlbeans.SchemaType
+import org.apache.xmlbeans.SchemaTypeSystem
+import org.apache.xmlbeans.XmlBeans
+import org.apache.xmlbeans.XmlError
+import org.apache.xmlbeans.XmlException
+import org.apache.xmlbeans.XmlOptions
 import org.apache.xmlbeans.impl.xb.xsdschema.SchemaDocument
-import org.apache.xmlbeans.impl.xsd2inst.SchemaInstanceGenerator
+import org.apache.xmlbeans.impl.xsd2inst.SampleXmlUtil
+import java.io.File
 import javax.xml.namespace.QName
 
+
 /**
+ * Serves an example of a given output type from a schema.
  *
  * @author Pete Cornish
  */
@@ -65,19 +75,44 @@ class SoapExampleService {
     fun serveExample(
         httpExchange: HttpExchange,
         schemas: Array<SchemaDocument>,
+        wsdlDir: File,
         outputTypeDefName: QName,
         bodyHolder: MessageBodyHolder,
     ): Boolean {
-        logger.debug("Generating example for $outputTypeDefName")
-
-        val example = SchemaInstanceGenerator.xsd2inst(
-            schemas,
-            outputTypeDefName.localPart,
-            SchemaInstanceGenerator.Xsd2InstOptions()
-        )
-
+        logger.debug("Generating example for {}", outputTypeDefName)
+        val example = generateInstanceFromSchemas(schemas, wsdlDir, outputTypeDefName.localPart)
         transmitExample(httpExchange, example, bodyHolder)
         return true
+    }
+
+    private fun generateInstanceFromSchemas(
+        schemas: Array<SchemaDocument>,
+        wsdlDir: File,
+        rootName: String,
+    ): String {
+        var sts: SchemaTypeSystem? = null
+        if (schemas.isNotEmpty()) {
+            val errors = mutableListOf<XmlError>()
+
+            val compileOptions = XmlOptions()
+                .setEntityResolver(WsdlRelativeXsdEntityResolver(wsdlDir))
+                .setErrorListener(errors)
+
+            try {
+                sts = XmlBeans.compileXsd(schemas, XmlBeans.getBuiltinTypeSystem(), compileOptions)
+            } catch (e: Exception) {
+                if (errors.isEmpty() || e !is XmlException) {
+                    logger.error("Error compiling XSD", e)
+                }
+                logger.error("Schema compilation errors: " + errors.joinToString("\n"))
+            }
+        }
+        sts ?: throw RuntimeException("No schemas to process")
+
+        val elem: SchemaType = sts.documentTypes().find { it.documentElementName.localPart == rootName }
+            ?: throw RuntimeException("Could not find a global element with name \"$rootName\"")
+
+        return SampleXmlUtil.createSampleForType(elem)
     }
 
     private fun transmitExample(httpExchange: HttpExchange, example: String?, bodyHolder: MessageBodyHolder) {

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/service/SoapExampleService.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/service/SoapExampleService.kt
@@ -95,6 +95,8 @@ class SoapExampleService {
             val errors = mutableListOf<XmlError>()
 
             val compileOptions = XmlOptions()
+                .setLoadLineNumbers()
+                .setLoadMessageDigest()
                 .setEntityResolver(WsdlRelativeXsdEntityResolver(wsdlDir))
                 .setErrorListener(errors)
 

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/Wsdl1Soap11WithXsdImportIncludeEndToEndTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/Wsdl1Soap11WithXsdImportIncludeEndToEndTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016-2024.
+ *
+ * This file is part of Imposter.
+ *
+ * "Commons Clause" License Condition v1.0
+ *
+ * The Software is provided to you by the Licensor under the License, as
+ * defined below, subject to the following condition.
+ *
+ * Without limiting other conditions in the License, the grant of rights
+ * under the License will not include, and the License does not grant to
+ * you, the right to Sell the Software.
+ *
+ * For purposes of the foregoing, "Sell" means practicing any or all of
+ * the rights granted to you under the License to provide to third parties,
+ * for a fee or other consideration (including without limitation fees for
+ * hosting or consulting/support services related to the Software), a
+ * product or service whose value derives, entirely or substantially, from
+ * the functionality of the Software. Any license notice or attribution
+ * required by the License must also include this Commons Clause License
+ * Condition notice.
+ *
+ * Software: Imposter
+ *
+ * License: GNU Lesser General Public License version 3
+ *
+ * Licensor: Peter Cornish
+ *
+ * Imposter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Imposter is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Imposter.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.gatehill.imposter.plugin.soap
+
+import io.gatehill.imposter.plugin.soap.util.SoapUtil
+
+/**
+ * Tests for [SoapPluginImpl] using WSDL v1 and SOAP 1.1 where XSDs are imported and included using
+ * relative paths.
+ */
+class Wsdl1Soap11WithXsdImportIncludeEndToEndTest : AbstractEndToEndTest() {
+    override val testConfigDirs = listOf("/wsdl1-soap11-xsd-import-include")
+    override val soapEnvNamespace = SoapUtil.soap11EnvNamespace
+    override val soapContentType = SoapUtil.soap11ContentType
+}

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Soap11ParserTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Soap11ParserTest.kt
@@ -64,7 +64,8 @@ class Wsdl1Soap11ParserTest {
     fun setUp() {
         val wsdlFile = File(Wsdl1Soap11ParserTest::class.java.getResource("/wsdl1-soap11/service.wsdl")!!.toURI())
         val document = SAXBuilder().build(wsdlFile)
-        parser = Wsdl1Parser(wsdlFile, document)
+        val entityResolver = WsdlRelativeXsdEntityResolver(wsdlFile.parentFile)
+        parser = Wsdl1Parser(wsdlFile, document, entityResolver)
     }
 
     @Test

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Soap12ParserTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Soap12ParserTest.kt
@@ -64,7 +64,8 @@ class Wsdl1Soap12ParserTest {
     fun setUp() {
         val wsdlFile = File(Wsdl1Soap12ParserTest::class.java.getResource("/wsdl1-soap12/service.wsdl")!!.toURI())
         val document = SAXBuilder().build(wsdlFile)
-        parser = Wsdl1Parser(wsdlFile, document)
+        val entityResolver = WsdlRelativeXsdEntityResolver(wsdlFile.parentFile)
+        parser = Wsdl1Parser(wsdlFile, document, entityResolver)
     }
 
     @Test

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl2Soap12ParserTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl2Soap12ParserTest.kt
@@ -64,7 +64,8 @@ class Wsdl2Soap12ParserTest {
     fun setUp() {
         val wsdlFile = File(Wsdl2Soap12ParserTest::class.java.getResource("/wsdl2-soap12/service.wsdl")!!.toURI())
         val document = SAXBuilder().build(wsdlFile)
-        parser = Wsdl2Parser(wsdlFile, document)
+        val entityResolver = WsdlRelativeXsdEntityResolver(wsdlFile.parentFile)
+        parser = Wsdl2Parser(wsdlFile, document, entityResolver)
     }
 
     @Test

--- a/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/PetService/schema-include.xsd
+++ b/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/PetService/schema-include.xsd
@@ -1,0 +1,19 @@
+<xs:schema elementFormDefault="unqualified" targetNamespace="urn:com:example:petstore" version="1.0"
+  xmlns:tns="urn:com:example:petstore"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:include schemaLocation="../include/include.xsd"/>
+
+  <xs:complexType name="petBreed">
+    <xs:all>
+      <xs:element name="id" type="xs:int"/>
+
+      <!--
+      Use the 'tns' prefix defined outside the inline schema
+      to test prefix inheritance for inline schemas.
+      -->
+      <xs:element name="name" type="tns:petBreedName"/>
+    </xs:all>
+  </xs:complexType>
+
+</xs:schema>

--- a/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/PetService/service.wsdl
+++ b/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/PetService/service.wsdl
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2023.
+  ~
+  ~ This file is part of Imposter.
+  ~
+  ~ "Commons Clause" License Condition v1.0
+  ~
+  ~ The Software is provided to you by the Licensor under the License, as
+  ~ defined below, subject to the following condition.
+  ~
+  ~ Without limiting other conditions in the License, the grant of rights
+  ~ under the License will not include, and the License does not grant to
+  ~ you, the right to Sell the Software.
+  ~
+  ~ For purposes of the foregoing, "Sell" means practicing any or all of
+  ~ the rights granted to you under the License to provide to third parties,
+  ~ for a fee or other consideration (including without limitation fees for
+  ~ hosting or consulting/support services related to the Software), a
+  ~ product or service whose value derives, entirely or substantially, from
+  ~ the functionality of the Software. Any license notice or attribution
+  ~ required by the License must also include this Commons Clause License
+  ~ Condition notice.
+  ~
+  ~ Software: Imposter
+  ~
+  ~ License: GNU Lesser General Public License version 3
+  ~
+  ~ Licensor: Peter Cornish
+  ~
+  ~ Imposter is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Lesser General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ Imposter is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with Imposter.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<definitions name="PetService" xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:tns="urn:com:example:petstore"
+             xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             targetNamespace="urn:com:example:petstore">
+
+    <documentation>
+        This is a sample WSDL 1.1 document describing the pet service.
+        It has SOAP 1.1 bindings.
+    </documentation>
+
+    <!-- Abstract type -->
+    <types>
+        <!-- imported schema -->
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                   xmlns="urn:com:example:petstore"
+                   targetNamespace="urn:com:example:petstore">
+
+            <xs:import namespace="urn:com:example:petstore"
+                       schemaLocation="../import/schema-import.xsd"/>
+        </xs:schema>
+
+        <!-- embedded schema -->
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                   xmlns="urn:com:example:petstore"
+                   targetNamespace="urn:com:example:petstore">
+
+            <xs:include schemaLocation="schema-include.xsd" />
+        </xs:schema>
+    </types>
+
+    <message name="getPetByIdRequest">
+        <part element="tns:getPetByIdRequest" name="parameters"/>
+    </message>
+    <message name="getPetByIdResponse">
+        <part element="tns:getPetByIdResponse" name="parameters"/>
+    </message>
+    <message name="getPetByNameRequest">
+        <part element="tns:getPetByNameRequest" name="parameters"/>
+    </message>
+    <message name="getPetByNameResponse">
+        <part element="tns:getPetByNameResponse" name="parameters"/>
+    </message>
+
+    <!-- Abstract port types -->
+    <portType name="PetPortType">
+        <operation name="getPetById">
+            <input message="tns:getPetByIdRequest" name="getPetByIdRequest"/>
+            <output message="tns:getPetByIdResponse" name="getPetByIdResponse"/>
+        </operation>
+        <operation name="getPetByName">
+            <input message="tns:getPetByNameRequest" name="getPetByNameRequest"/>
+            <output message="tns:getPetByNameResponse" name="getPetByNameResponse"/>
+        </operation>
+    </portType>
+
+    <!-- Concrete Binding Over HTTP -->
+    <binding name="HttpBinding" type="tns:PetPortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+
+        <operation name="getPetById">
+            <soap:operation soapAction="getPetById" style="document"/>
+            <input name="getPetByIdRequest">
+                <soap:body use="literal"/>
+            </input>
+            <output name="getPetByIdResponse">
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="getPetByName">
+            <soap:operation soapAction="getPetByName" style="document"/>
+            <input name="getPetByNameRequest">
+                <soap:body use="literal"/>
+            </input>
+            <output name="getPetByNameResponse">
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+    </binding>
+
+    <!-- Concrete Binding with SOAP-->
+    <binding name="SoapBinding" type="tns:PetPortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/soap"/>
+
+        <operation name="getPetById">
+            <soap:operation soapAction="getPetById" style="document"/>
+            <input name="getPetByIdRequest">
+                <soap:body use="literal"/>
+            </input>
+            <output name="getPetByIdResponse">
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+
+        <operation name="getPetByName">
+            <!-- soap:operation style omitted - fall back to soap:binding style -->
+            <soap:operation soapAction="getPetByName"/>
+            <input name="getPetByNameRequest">
+                <soap:body use="literal"/>
+            </input>
+            <output name="getPetByNameResponse">
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+    </binding>
+
+    <!-- Web Service offering endpoints for both bindings-->
+    <service name="PetService">
+        <port name="HttpEndpoint" binding="tns:HttpBinding">
+            <soap:address location="http://www.example.com/http/"/>
+        </port>
+        <port name="SoapEndpoint" binding="tns:SoapBinding">
+            <soap:address location="http://www.example.com/soap/"/>
+        </port>
+    </service>
+</definitions>

--- a/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/PetService/service.wsdl
+++ b/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/PetService/service.wsdl
@@ -65,7 +65,7 @@
                        schemaLocation="../import/schema-import.xsd"/>
         </xs:schema>
 
-        <!-- embedded schema -->
+        <!-- included schema -->
         <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
                    xmlns="urn:com:example:petstore"
                    targetNamespace="urn:com:example:petstore">

--- a/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/getPetByNameResponse.xml
+++ b/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/getPetByNameResponse.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:env="http://www.w3.org/2001/12/soap-envelope">
+    <env:Header/>
+    <env:Body>
+        <getPetByNameResponse xmlns="urn:com:example:petstore">
+            <id>3</id>
+            <name>Fluffy</name>
+        </getPetByNameResponse>
+    </env:Body>
+</env:Envelope>

--- a/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/import/import.xsd
+++ b/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/import/import.xsd
@@ -1,0 +1,9 @@
+<xs:schema elementFormDefault="unqualified" targetNamespace="urn:foo:bar" version="1.0"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:complexType name="foo">
+    <xs:sequence>
+      <xs:element name="bar" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/import/schema-import.xsd
+++ b/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/import/schema-import.xsd
@@ -1,0 +1,33 @@
+<xs:schema elementFormDefault="unqualified" targetNamespace="urn:com:example:petstore" version="1.0"
+  xmlns:tns="urn:com:example:petstore"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:import namespace="urn:foo:bar" schemaLocation="import.xsd"/>
+
+    <xs:complexType name="petType">
+        <xs:all>
+            <xs:element name="id" type="xs:int"/>
+            <xs:element name="name" type="xs:string"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="getPetByIdRequest">
+        <xs:all>
+            <xs:element name="id" type="xs:int"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="getPetByNameRequest">
+        <xs:all>
+            <xs:element name="name" type="xs:string"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:element name="getPetByIdRequest" type="tns:getPetByIdRequest"/>
+    <xs:element name="getPetByIdResponse" type="tns:petType"/>
+
+    <xs:element name="getPetByNameRequest" type="tns:getPetByNameRequest"/>
+    <xs:element name="getPetByNameResponse" type="tns:petType"/>
+
+    <xs:element name="fault" type="xs:string"/>
+</xs:schema>

--- a/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/imposter-config.yaml
+++ b/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/imposter-config.yaml
@@ -1,0 +1,13 @@
+plugin: soap
+wsdlFile: PetService/service.wsdl
+
+resources:
+  - binding: SoapBinding
+    operation: getPetByName
+    response:
+      file: getPetByNameResponse.xml
+
+  - binding: HttpBinding
+    operation: getPetByName
+    response:
+      file: getPetByNameResponse.xml

--- a/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/include/include.xsd
+++ b/mock/soap/src/test/resources/wsdl1-soap11-xsd-import-include/include/include.xsd
@@ -1,0 +1,12 @@
+<xs:schema elementFormDefault="unqualified" targetNamespace="urn:com:example:petstore" version="1.0"
+  xmlns:tns="urn:com:example:petstore"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:simpleType name="petBreedName">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+      <xs:maxLength value="20"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>


### PR DESCRIPTION
Currently, WSDLs with xs:include fail parsing.
This fix configures XMLBeans to look for XML schemas which are include/imported relative to the folder having the configured WSDL.

fixes #548