### PR TITLE
fix: support messages having a part attribute without namespace prefix

### DIFF
--- a/mock/soap/build.gradle
+++ b/mock/soap/build.gradle
@@ -22,6 +22,9 @@ dependencies {
 
     // sample client
     testImplementation project(':test:sample-soap-client')
+
+    // mocking
+    implementation "org.mockito:mockito-core:$version_mockito"
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/AbstractWsdlParser.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/AbstractWsdlParser.kt
@@ -123,6 +123,8 @@ abstract class AbstractWsdlParser(
 
     protected abstract fun findEmbeddedTypesSchemaNodes(): List<Element>
 
+    protected abstract fun resolveTargetNamespace(): String?
+
     protected fun selectSingleNodeWithName(context: Any, expressionTemplate: String, name: String): Element? {
         return selectSingleNode(context, String.format(expressionTemplate, name))
             ?: name.takeIf { it.contains(":") }?.let {
@@ -191,6 +193,10 @@ abstract class AbstractWsdlParser(
 
         val valueParts = attrValue.split(':')
         if (valueParts.size == 1) {
+            val tns = resolveTargetNamespace()
+            if (tns != null) {
+                return QName(tns, valueParts[0]);
+            }
             // unqualified name
             return QName(valueParts[0])
         } else {

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/AbstractWsdlParser.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/AbstractWsdlParser.kt
@@ -184,7 +184,7 @@ abstract class AbstractWsdlParser(
         return matchingType
     }
 
-    protected fun getAttributeValueAsQName(element: Element, attributeName: String): QName? {
+    protected open fun getAttributeValueAsQName(element: Element, attributeName: String): QName? {
         val attr = element.getAttribute(attributeName)
             ?: return null
 

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Parser.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Parser.kt
@@ -78,8 +78,7 @@ class Wsdl1Parser(
 
     override val services: List<WsdlService>
         get() {
-            val tns = selectSingleNode(document, "/wsdl:definitions")
-                ?.getAttribute("targetNamespace")?.value
+            val tns = resolveTargetNamespace()
 
             val services = selectNodes(document, "/wsdl:definitions/wsdl:service")
 
@@ -295,6 +294,11 @@ class Wsdl1Parser(
     override fun findEmbeddedTypesSchemaNodes(): List<Element> {
         val xsNamespaces = xPathNamespaces + Namespace.getNamespace("xs", SoapUtil.NS_XML_SCHEMA)
         return BodyQueryUtil.selectNodes(document, "/wsdl:definitions/wsdl:types/xs:schema", xsNamespaces)
+    }
+
+    override fun resolveTargetNamespace(): String? {
+        return selectSingleNode(document, "/wsdl:definitions")
+            ?.getAttribute("targetNamespace")?.value
     }
 
     /**

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/Wsdl2Parser.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/Wsdl2Parser.kt
@@ -209,6 +209,11 @@ class Wsdl2Parser(
         return BodyQueryUtil.selectNodes(document, "/wsdl:description/wsdl:types/xs:schema", xsNamespaces)
     }
 
+    override fun resolveTargetNamespace(): String? {
+        return selectSingleNode(document, "/wsdl:description")
+            ?.getAttribute("targetNamespace")?.value
+    }
+
     companion object {
         const val wsdl2Namespace = "http://www.w3.org/ns/wsdl"
     }

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/AbstractWsdlParserTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/AbstractWsdlParserTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * This file is part of Imposter.
+ *
+ * "Commons Clause" License Condition v1.0
+ *
+ * The Software is provided to you by the Licensor under the License, as
+ * defined below, subject to the following condition.
+ *
+ * Without limiting other conditions in the License, the grant of rights
+ * under the License will not include, and the License does not grant to
+ * you, the right to Sell the Software.
+ *
+ * For purposes of the foregoing, "Sell" means practicing any or all of
+ * the rights granted to you under the License to provide to third parties,
+ * for a fee or other consideration (including without limitation fees for
+ * hosting or consulting/support services related to the Software), a
+ * product or service whose value derives, entirely or substantially, from
+ * the functionality of the Software. Any license notice or attribution
+ * required by the License must also include this Commons Clause License
+ * Condition notice.
+ *
+ * Software: Imposter
+ *
+ * License: GNU Lesser General Public License version 3
+ *
+ * Licensor: Peter Cornish
+ *
+ * Imposter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Imposter is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Imposter.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.gatehill.imposter.plugin.soap.parser
+
+import io.gatehill.imposter.plugin.soap.model.WsdlService
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.emptyString
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.notNullValue
+import org.jdom2.Document
+import org.jdom2.Element
+import org.jdom2.Namespace
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.xml.sax.EntityResolver
+import java.io.File
+import javax.xml.namespace.QName
+
+/**
+ * Tests for [AbstractWsdlParser].
+ *
+ * @author pete
+ */
+class AbstractWsdlParserTest {
+    @Test
+    fun `test getAttributeValueAsQName with unqualified attribute and no target namespace`() {
+        val parser = TestWsdlParser(File("."), Document(), mock(), targetNamespace = null)
+        val element = Element("pet", "pets", "urn:com:example:petstore")
+        element.setAttribute("noNsAttribute", "foo")
+
+        val value = parser.getAttributeValueAsQName(element, "noNsAttribute")
+        assertThat(value, notNullValue())
+        assertThat(value?.prefix, emptyString())
+        assertThat(value?.namespaceURI, emptyString())
+        assertThat(value?.localPart, equalTo("foo"))
+    }
+
+    @Test
+    fun `test getAttributeValueAsQName with qualified attribute and no target namespace`() {
+        val parser = TestWsdlParser(File("."), Document(), mock(), targetNamespace = null)
+        val element = Element("pet", "pets", "urn:com:example:petstore")
+        element.setAttribute("noNsAttribute", "pets:foo")
+
+        val value = parser.getAttributeValueAsQName(element, "noNsAttribute")
+        assertThat(value, notNullValue())
+        assertThat(value?.prefix, equalTo("pets"))
+        assertThat(value?.namespaceURI, equalTo("urn:com:example:petstore"))
+        assertThat(value?.localPart, equalTo("foo"))
+    }
+
+    @Test
+    fun `test getAttributeValueAsQName with unqualified attribute and a target namespace`() {
+        val parser = TestWsdlParser(File("."), Document(), mock(), targetNamespace = "urn:com:example:petstore")
+        val element = Element("pet", "pets", "urn:com:example:petstore")
+        element.setAttribute("noNsAttribute", "foo")
+
+        val value = parser.getAttributeValueAsQName(element, "noNsAttribute")
+        assertThat(value, notNullValue())
+        assertThat(value?.prefix, emptyString())
+        assertThat(value?.namespaceURI, equalTo("urn:com:example:petstore"))
+        assertThat(value?.localPart, equalTo("foo"))
+    }
+
+    @Test
+    fun `test getAttributeValueAsQName with qualified attribute and a target namespace`() {
+        val parser = TestWsdlParser(File("."), Document(), mock(), targetNamespace = "urn:com:example:petstore")
+        val element = Element("pet", "pets", "urn:com:example:petstore")
+        element.setAttribute("noNsAttribute", "pets:foo")
+
+        val value = parser.getAttributeValueAsQName(element, "noNsAttribute")
+        assertThat(value, notNullValue())
+        assertThat(value?.prefix, equalTo("pets"))
+        assertThat(value?.namespaceURI, equalTo("urn:com:example:petstore"))
+        assertThat(value?.localPart, equalTo("foo"))
+    }
+
+    private class TestWsdlParser(
+        wsdlFile: File,
+        document: Document,
+        entityResolver: EntityResolver,
+        private val targetNamespace: String?,
+    ) : AbstractWsdlParser(
+        wsdlFile, document, entityResolver
+    ) {
+        override fun resolveTargetNamespace() = targetNamespace
+
+        public override fun getAttributeValueAsQName(element: Element, attributeName: String): QName? {
+            return super.getAttributeValueAsQName(element, attributeName)
+        }
+
+        override fun findEmbeddedTypesSchemaNodes() = TODO("Not yet implemented")
+        override val xPathNamespaces: List<Namespace>
+            get() = TODO("Not yet implemented")
+        override val version: WsdlParser.WsdlVersion
+            get() = TODO("Not yet implemented")
+
+        override val services: List<WsdlService>
+            get() = TODO("Not yet implemented")
+
+        override fun getBinding(bindingName: String) = TODO("Not yet implemented")
+
+        override fun getInterface(interfaceName: String) = TODO("Not yet implemented")
+    }
+}

--- a/mock/soap/src/test/resources/wsdl1-soap11-document/service.wsdl
+++ b/mock/soap/src/test/resources/wsdl1-soap11-document/service.wsdl
@@ -93,7 +93,8 @@
     </types>
 
     <message name="getPetByIdRequest">
-        <part element="tns:getPetByIdRequest" name="parameters"/>
+        <!-- no namespace prefix for the element, so fallback to WSDL targetNamespace -->
+        <part element="getPetByIdRequest" name="parameters"/>
     </message>
     <message name="getPetByIdResponse">
         <part element="tns:getPetByIdResponse" name="parameters"/>

--- a/mock/soap/src/test/resources/wsdl1-soap11-filter-message-parts/service.wsdl
+++ b/mock/soap/src/test/resources/wsdl1-soap11-filter-message-parts/service.wsdl
@@ -93,7 +93,7 @@
 
     <message name="getPetByIdRequest">
         <part type="xs:string" name="header"/>
-        <part element="getPetByIdRequest" name="body"/>
+        <part element="tns:getPetByIdRequest" name="body"/>
     </message>
     <message name="getPetByIdResponse">
         <part element="tns:getPetByIdResponse" name="body"/>

--- a/mock/soap/src/test/resources/wsdl1-soap11-filter-message-parts/service.wsdl
+++ b/mock/soap/src/test/resources/wsdl1-soap11-filter-message-parts/service.wsdl
@@ -93,7 +93,7 @@
 
     <message name="getPetByIdRequest">
         <part type="xs:string" name="header"/>
-        <part element="tns:getPetByIdRequest" name="body"/>
+        <part element="getPetByIdRequest" name="body"/>
     </message>
     <message name="getPetByIdResponse">
         <part element="tns:getPetByIdResponse" name="body"/>

--- a/mock/soap/src/test/resources/wsdl2-soap12/service.wsdl
+++ b/mock/soap/src/test/resources/wsdl2-soap12/service.wsdl
@@ -98,6 +98,7 @@ http://www.w3.org/ns/wsdl/soap http://www.w3.org/2002/ws/desc/ns/soap.xsd">
 
         <operation name="getPetById" pattern="http://www.w3.org/ns/wsdl/in-out">
             <wsoap:operation soapAction="getPetById" style="document"/>
+            <!-- no namespace prefix for the element, so fallback to WSDL targetNamespace -->
             <input messageLabel="In" element="getPetByIdRequest"/>
             <output messageLabel="Out" element="tns:getPetByIdResponse"/>
         </operation>

--- a/mock/soap/src/test/resources/wsdl2-soap12/service.wsdl
+++ b/mock/soap/src/test/resources/wsdl2-soap12/service.wsdl
@@ -98,7 +98,7 @@ http://www.w3.org/ns/wsdl/soap http://www.w3.org/2002/ws/desc/ns/soap.xsd">
 
         <operation name="getPetById" pattern="http://www.w3.org/ns/wsdl/in-out">
             <wsoap:operation soapAction="getPetById" style="document"/>
-            <input messageLabel="In" element="tns:getPetByIdRequest"/>
+            <input messageLabel="In" element="getPetByIdRequest"/>
             <output messageLabel="Out" element="tns:getPetByIdResponse"/>
         </operation>
 


### PR DESCRIPTION
* Function to resolve the targetNamespace from the WSDL-document. If such a target namespace is declared and e.g. the element attribute of the message part has no namespace prefix, use that target namespace to construct a qualified name.
* Adapt random test WSDLs to have no namespace prefix

fixes #569