### PR TITLE
refactor: switch to bracketed params internally

### DIFF
--- a/adapter/awslambda/src/test/resources/simple/config/imposter-config.yaml
+++ b/adapter/awslambda/src/test/resources/simple/config/imposter-config.yaml
@@ -2,7 +2,7 @@ plugin: "openapi"
 specFile: "pet-api.yaml"
 
 resources:
-  - path: /pets/:petId
+  - path: /pets/{petId}
     method: get
     pathParams:
       petId: 2

--- a/adapter/vertxweb/src/test/java/io/gatehill/imposter/server/vertxweb/util/VertxResourceUtilTest.kt
+++ b/adapter/vertxweb/src/test/java/io/gatehill/imposter/server/vertxweb/util/VertxResourceUtilTest.kt
@@ -56,9 +56,27 @@ import org.junit.jupiter.api.Test
  */
 class VertxResourceUtilTest {
     @Test
+    fun `should convert path to Vertx format`() {
+        val normalisedParams = mutableMapOf<String, String>()
+        val result = VertxResourceUtil.normalisePath(normalisedParams, "/{pathParam}/notParam")
+
+        assertEquals(0, normalisedParams.size)
+        assertEquals("/:pathParam/notParam", result)
+    }
+
+    @Test
+    fun `should handle param and plain string`() {
+        val normalisedParams = mutableMapOf<String, String>()
+        val result = VertxResourceUtil.normalisePath(normalisedParams, "/{firstParam}.notParam")
+
+        assertEquals(0, normalisedParams.size)
+        assertEquals("/:firstParam.notParam", result)
+    }
+
+    @Test
     fun `should normalise path`() {
         val normalisedParams = mutableMapOf<String, String>()
-        val result = VertxResourceUtil.normalisePath(normalisedParams, "/:firstParam/:second-param/notParam")
+        val result = VertxResourceUtil.normalisePath(normalisedParams, "/{firstParam}/{second-param}/notParam")
 
         assertEquals(1, normalisedParams.size)
         assertFalse(normalisedParams.containsKey("firstParam"))

--- a/core/api/src/test/java/io/gatehill/imposter/util/ResourceUtilTest.kt
+++ b/core/api/src/test/java/io/gatehill/imposter/util/ResourceUtilTest.kt
@@ -1,0 +1,57 @@
+package io.gatehill.imposter.util
+
+import io.gatehill.imposter.http.HttpMethod
+import io.gatehill.imposter.plugin.config.resource.ResourceConfig
+import io.gatehill.imposter.plugin.config.resource.RestResourceConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Tests for [ResourceUtil].
+ */
+class ResourceUtilTest {
+    @Test
+    fun `convertPathParamsToBracketFormat should convert colon format to bracket format`() {
+        val result = ResourceUtil.convertPathParamsToBracketFormat("/example/:foo")
+        assertEquals("/example/{foo}", result)
+    }
+
+    @Test
+    fun `convertPathParamsToBracketFormat should support mix of placeholders and strings`() {
+        assertEquals(
+            "/example/{foo}-bar",
+            ResourceUtil.convertPathParamsToBracketFormat("/example/:foo-bar"),
+        )
+        assertEquals(
+            "/example/{foo}.bar",
+            ResourceUtil.convertPathParamsToBracketFormat("/example/:foo.bar"),
+        )
+        assertEquals(
+            "/example/baz.{foo}",
+            ResourceUtil.convertPathParamsToBracketFormat("/example/baz.:foo"),
+        )
+    }
+
+    @Test
+    fun `convertPathParamsToBracketFormat should return null when input is null`() {
+        val result = ResourceUtil.convertPathParamsToBracketFormat(null)
+        assertNull(result)
+    }
+
+    @Test
+    fun `extractResourceMethod should return method from MethodResourceConfig`() {
+        val resourceConfig = RestResourceConfig().apply { method = HttpMethod.POST }
+        val result = ResourceUtil.extractResourceMethod(resourceConfig)
+        assertEquals(HttpMethod.POST, result)
+    }
+
+    @Test
+    fun `extractResourceMethod should return GET when resourceConfig is not MethodResourceConfig`() {
+        val resourceConfig = object : ResourceConfig {
+            override var path: String? = "/example"
+        }
+        val result = ResourceUtil.extractResourceMethod(resourceConfig)
+        assertEquals(HttpMethod.GET, result)
+    }
+}

--- a/core/config-dynamic/src/test/resources/config/test-config.json
+++ b/core/config-dynamic/src/test/resources/config/test-config.json
@@ -4,7 +4,7 @@
   "contentType": "application/json",
   "resources": [
     {
-      "path": "/:id",
+      "path": "/{id}",
       "type": "ARRAY",
       "response": {
         "staticFile": "rest-plugin-list-data.json"

--- a/core/config-dynamic/src/test/resources/config/test-config.yaml
+++ b/core/config-dynamic/src/test/resources/config/test-config.yaml
@@ -3,7 +3,7 @@ plugin: io.gatehill.imposter.core.test.ExamplePluginImpl
 path: "/example"
 contentType: application/json
 resources:
-  - path: "/:id"
+  - path: "/{id}"
     type: ARRAY
     response:
       file: rest-plugin-list-data.json

--- a/core/config-resolver-s3/src/test/resources/config/imposter-config.yaml
+++ b/core/config-resolver-s3/src/test/resources/config/imposter-config.yaml
@@ -2,7 +2,7 @@ plugin: "openapi"
 specFile: "pet-api.yaml"
 
 resources:
-  - path: /pets/:petId
+  - path: /pets/{petId}
     method: get
     pathParams:
       petId: 2

--- a/core/config/src/main/java/io/gatehill/imposter/config/util/ConfigUtil.kt
+++ b/core/config/src/main/java/io/gatehill/imposter/config/util/ConfigUtil.kt
@@ -295,10 +295,10 @@ object ConfigUtil {
             check(config.plugin != null) { "No plugin specified in configuration file: $configFile" }
             config.dir = configFile.parentFile
 
-            // convert any OpenAPI format path parameters
+            // normalise path param format
             if (config is ResourcesHolder<*>) {
                 (config as ResourcesHolder<*>).resources?.forEach { resource ->
-                    resource.path = ResourceUtil.convertPathFromOpenApi(resource.path)
+                    resource.path = ResourceUtil.convertPathParamsToBracketFormat(resource.path)
                 }
             }
 

--- a/core/config/src/test/java/io/gatehill/imposter/config/ConfigUtilTest.kt
+++ b/core/config/src/test/java/io/gatehill/imposter/config/ConfigUtilTest.kt
@@ -181,9 +181,13 @@ class ConfigUtilTest {
         assertThat("resource response status code should be set", exampleResource?.responseConfig?.statusCode, equalTo(200))
         assertThat("resource response content should be set", exampleResource?.responseConfig?.content, equalTo("example"))
 
-        val openApiStyleResource = config.resources?.find { it.path?.startsWith("/openapi-style") == true }
-        assertNotNull("openapi style resource should be set", openApiStyleResource)
-        assertThat("openapi style resource path should be converted to vertx style", openApiStyleResource?.path, equalTo("/openapi-style/:param1"))
+        val bracketStylePathResource = config.resources?.find { it.path?.startsWith("/bracket-style") == true }
+        assertNotNull("bracket style resource should be set", bracketStylePathResource)
+        assertThat("bracket style resource path should be preserved", bracketStylePathResource?.path, equalTo("/bracket-style/{param1}"))
+
+        val vertxStylePathResource = config.resources?.find { it.path?.startsWith("/vertx-style") == true }
+        assertNotNull("vertx style resource should be set", vertxStylePathResource)
+        assertThat("vertx style resource path should be converted to bracketed style", vertxStylePathResource?.path, equalTo("/vertx-style/{param1}"))
     }
 
     /**

--- a/core/config/src/test/resources/simple/test-config.yaml
+++ b/core/config/src/test/resources/simple/test-config.yaml
@@ -7,7 +7,12 @@ resources:
     statusCode: 200
     content: "example"
 
-- path: /openapi-style/{param1}
+- path: /bracket-style/{param1}
+  method: GET
+  response:
+    statusCode: 200
+
+- path: /vertx-style/:param1
   method: GET
   response:
     statusCode: 200

--- a/core/engine/src/main/java/io/gatehill/imposter/Imposter.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/Imposter.kt
@@ -47,7 +47,6 @@ import io.gatehill.imposter.config.LoadedConfig
 import io.gatehill.imposter.config.util.ConfigUtil
 import io.gatehill.imposter.config.util.EnvVars
 import io.gatehill.imposter.config.util.MetaUtil
-import io.gatehill.imposter.http.HttpRoute
 import io.gatehill.imposter.http.HttpRouter
 import io.gatehill.imposter.http.SingletonResourceMatcher
 import io.gatehill.imposter.inject.BootstrapModule
@@ -69,6 +68,7 @@ import io.gatehill.imposter.util.AsyncUtil
 import io.gatehill.imposter.util.HttpUtil
 import io.gatehill.imposter.util.InjectorUtil
 import io.gatehill.imposter.util.MetricsUtil
+import io.gatehill.imposter.util.ResourceUtil
 import io.gatehill.imposter.util.splitOnCommaAndTrim
 import io.gatehill.imposter.util.supervisedDefaultCoroutineScope
 import io.vertx.core.Promise
@@ -230,16 +230,10 @@ class Imposter(
 
         if (preferExactMatchRoutes) {
             LOGGER.trace("Ordering routes by exact matches first")
-            router.routes.sortWith { r1, r2 -> countPlaceholders(r1) - countPlaceholders(r2) }
+            router.routes.sortWith { r1, r2 -> ResourceUtil.countPlaceholders(r1) - ResourceUtil.countPlaceholders(r2) }
         }
 
         return router
-    }
-
-    private fun countPlaceholders(route: HttpRoute): Int {
-        return route.path?.let { path -> path.count { it == ':' } }
-            ?: route.regex?.let { 1000 } // weight regex more than placeholders
-            ?: 0
     }
 
     fun stop(promise: Promise<Void>) {

--- a/core/http/src/main/java/io/gatehill/imposter/http/HttpRoute.kt
+++ b/core/http/src/main/java/io/gatehill/imposter/http/HttpRoute.kt
@@ -65,10 +65,10 @@ data class HttpRoute(
         path ?: return@lazy null
 
         val paramNames = mutableListOf<String>()
-        val matcher = placeholderPattern.matcher(path)
+        val matcher = PATH_PARAM_PLACEHOLDER.matcher(path)
         val sb = StringBuffer()
         while (matcher.find()) {
-            val paramName: String = matcher.group().substring(1)
+            val paramName: String = matcher.group(1)
             require(!paramNames.contains(paramName)) { "Cannot use param name '$paramName' more than once in path" }
 
             matcher.appendReplacement(sb, "(?<$paramName>[^/]+)")
@@ -98,7 +98,7 @@ data class HttpRoute(
 
     private fun isPathPlaceholderMatch(requestPath: String): Boolean {
         parsedPathParams?.let { pathParams ->
-            if (path?.contains(':') == true) {
+            if (path?.contains('{') == true) {
                 val matcher = pathParams.pathPattern.matcher(requestPath)
                 if (matcher.matches()) {
                     return true
@@ -129,6 +129,9 @@ data class HttpRoute(
     }
 
     companion object {
-        private val placeholderPattern = Pattern.compile(":([A-Za-z][A-Za-z0-9_]*)")
+        /**
+         * Path parameter placeholders are bracketed, e.g. `{paramName}`.
+         */
+        val PATH_PARAM_PLACEHOLDER: Pattern = Pattern.compile("\\{([a-zA-Z0-9._\\-]+)}")
     }
 }

--- a/distro/awslambda/deploy/example/config/imposter-config.yaml
+++ b/distro/awslambda/deploy/example/config/imposter-config.yaml
@@ -2,7 +2,7 @@ plugin: "openapi"
 specFile: "pet-api.yaml"
 
 resources:
-  - path: /pets/:petId
+  - path: /pets/{petId}
     method: get
     pathParams:
       petId: 2

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,7 +94,7 @@ A few things to call out:
 
 #### Multiple resources example
 
-The [OpenAPI plugin](./openapi_plugin.md) and [REST plugin](./rest_plugin.md) allow you to specify multiple resources, using the `resources` array. Each resource can have its own path, method, response behaviour etc.
+The [OpenAPI plugin](./openapi_plugin.md), [SOAP plugin](./soap_plugin.md) and [REST plugin](./rest_plugin.md) allow you to specify multiple resources, using the `resources` array. Each resource can have its own path, method, response behaviour etc.
 
 ```yaml
 # multi-response-config.yaml
@@ -200,7 +200,7 @@ resources:
       statusCode: 200
   
   # handles GET /pets/10
-  - path: "/pets/:petId"
+  - path: "/pets/{petId}"
     method: GET
     pathParams:
       petId: 10
@@ -208,8 +208,8 @@ resources:
       statusCode: 401
       content: "You do not have permission to view this pet."
   
-  # handles PUT /pets/:petId with a request header 'X-Pet-Username: foo'
-  - path: "/pets/:petId"
+  # handles PUT /pets/{petId} with a request header 'X-Pet-Username: foo'
+  - path: "/pets/{petId}"
     method: PUT
     requestHeaders:
       X-Pet-Username: foo

--- a/docs/data_capture.md
+++ b/docs/data_capture.md
@@ -16,7 +16,7 @@ Use the `capture` block of a resource, as follows:
 
 ```yaml
 resources:
-- path: "/users/:userName"
+- path: "/users/{userName}"
   method: PUT
   capture:
     user:
@@ -38,7 +38,7 @@ Note that the name of the item is the object key - in the above example it is `u
 
 ```yaml
 resources:
-- path: "/users/:userName"
+- path: "/users/{userName}"
   method: PUT
   capture:
     user:
@@ -57,7 +57,7 @@ The following configuration options are available for a capture:
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | capture block key | The name of the item to capture, e.g. `user`.                                                                                                                 |
 | `store`           | The name of the store in which to put the item.                                                                                                               |
-| `pathParam`       | The name of the path parameter to capture. Must reference the resource path, e.g. `userId` for a path of `/users/:userId`                                     |
+| `pathParam`       | The name of the path parameter to capture. Must reference the resource path, e.g. `userId` for a path of `/users/{userId}`                                    |
 | `queryParam`      | The name of the query parameter to capture.                                                                                                                   |
 | `formParam`       | The name of the form parameter to capture.                                                                                                                    |
 | `requestHeader`   | The name of the request header to capture.                                                                                                                    |
@@ -174,7 +174,7 @@ Example:
 # part of your configuration file
 
 resources:
-  - path: "/people/:team/:person"
+  - path: "/people/{team}/{person}"
     method: POST
     capture:
       personInTeam:
@@ -267,7 +267,7 @@ plugin: rest
 
 resources:
 - method: PUT
-  path: /users/admins/:userId
+  path: /users/admins/{userId}
   capture:
     adminUser:
       expression: "${datetime.now.iso8601_datetime}"
@@ -287,7 +287,7 @@ plugin: rest
 
 resources:
 - method: PUT
-  path: /users/admins/:userId
+  path: /users/admins/{userId}
   capture:
     adminUser:
       expression: "${datetime.now.iso8601_datetime}"
@@ -314,7 +314,7 @@ Here is an example combining capture and response template:
 # part of your configuration file
 
 resources:
-  - path: "/users/:userName"
+  - path: "/users/{userName}"
     method: PUT
     capture:
       user:

--- a/docs/openapi_plugin.md
+++ b/docs/openapi_plugin.md
@@ -224,7 +224,7 @@ resources:
     response:
       statusCode: 201
 
-  - path: "/pets/:petId"
+  - path: "/pets/{petId}"
     method: put
     response:
       statusCode: 202

--- a/docs/rest_plugin.md
+++ b/docs/rest_plugin.md
@@ -72,11 +72,11 @@ We can configure different responses at multiple paths as follows:
     plugin: rest
     contentType: application/json
     resources:
-      - path: "/cats/:id"
+      - path: "/cats/{id}"
         type: array
         response:
           file: cats.json
-      - path: "/dogs/:id"
+      - path: "/dogs/{id}"
         type: array
         response:
           file: dogs.json
@@ -84,7 +84,7 @@ We can configure different responses at multiple paths as follows:
 A few things to call out:
 
 * We’ve defined the endpoint `/cats` to return the contents of our sample JSON file; in other words an array of cats.
-* We’ve also said that, because the response file is a JSON array, we want to allow querying of individual items by their ID, under the `/cats/:id` endpoint.
+* We’ve also said that, because the response file is a JSON array, we want to allow querying of individual items by their ID, under the `/cats/{id}` endpoint.
 * This example assumes you’ve named the file containing your JSON array `cats.json` and that it is in the same directory as the configuration file.
 
 Let's return an array of data at each endpoint:

--- a/examples/openapi/override-status-code/override-status-code-config.yaml
+++ b/examples/openapi/override-status-code/override-status-code-config.yaml
@@ -20,13 +20,13 @@ resources:
     response:
       statusCode: 201
 
-  - path: "/pets/:petId"
+  - path: "/pets/{petId}"
     method: "put"
     response:
       statusCode: 202
 
   # handles GET /pets/10
-  - path: "/pets/:petId"
+  - path: "/pets/{petId}"
     method: GET
     pathParams:
       petId: 10
@@ -34,8 +34,8 @@ resources:
       statusCode: 401
       content: "You do not have permission to view this pet."
 
-  # handles PUT /pets/:petId with a request header 'X-Pet-Username: foo'
-  - path: "/pets/:petId"
+  # handles PUT /pets/{petId} with a request header 'X-Pet-Username: foo'
+  - path: "/pets/{petId}"
     method: PUT
     requestHeaders:
       X-Pet-Username: foo

--- a/examples/rest/data-capture/imposter-config.yaml
+++ b/examples/rest/data-capture/imposter-config.yaml
@@ -2,7 +2,7 @@ plugin: rest
 
 resources:
 - method: GET
-  path: /users/:userId
+  path: /users/{userId}
   capture:
     userId:
       pathParam: userId
@@ -29,7 +29,7 @@ resources:
     statusCode: 200
 
 - method: PUT
-  path: /users/admins/:userId
+  path: /users/admins/{userId}
   capture:
     # constant value, but dynamic key
     adminUser:

--- a/examples/rest/multiple/multi-response-config.yaml
+++ b/examples/rest/multiple/multi-response-config.yaml
@@ -2,11 +2,11 @@
 plugin: rest
 contentType: application/json
 resources:
-  - path: "/cats/:id"
+  - path: "/cats/{id}"
     type: array
     response:
       file: cats.json
-  - path: "/dogs/:id"
+  - path: "/dogs/{id}"
     type: array
     response:
       file: dogs.json

--- a/examples/rest/response-template/imposter-config.yaml
+++ b/examples/rest/response-template/imposter-config.yaml
@@ -8,7 +8,7 @@ resources:
     template: true
 
 - method: PUT
-  path: /pets/:petId
+  path: /pets/{petId}
   capture:
     petId:
       pathParam: petId

--- a/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/OpenApiPluginImpl.kt
+++ b/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/OpenApiPluginImpl.kt
@@ -71,7 +71,6 @@ import io.gatehill.imposter.util.HttpUtil
 import io.gatehill.imposter.util.LogUtil.describeRequestShort
 import io.gatehill.imposter.util.MapUtil.addJavaTimeSupport
 import io.gatehill.imposter.util.ResourceUtil
-import io.gatehill.imposter.util.ResourceUtil.convertPathFromOpenApi
 import io.gatehill.imposter.util.completedUnitFuture
 import io.gatehill.imposter.util.makeFuture
 import io.swagger.util.Json
@@ -243,20 +242,18 @@ class OpenApiPluginImpl @Inject constructor(
      * Construct the full path from the base path and the operation path.
      *
      * @param pathPrefix
-     * @param specOperationPath the operation path from the OpenAPI specification
+     * @param operationPath the operation path from the OpenAPI specification
      * @return the full path
      */
-    private fun buildFullPath(pathPrefix: String, specOperationPath: String): String {
-        val operationPath = convertPathFromOpenApi(specOperationPath)
-
+    private fun buildFullPath(pathPrefix: String, operationPath: String): String {
         return if (pathPrefix.endsWith("/")) {
-            if (operationPath!!.startsWith("/")) {
+            if (operationPath.startsWith("/")) {
                 pathPrefix + operationPath.substring(1)
             } else {
                 pathPrefix + operationPath
             }
         } else {
-            if (operationPath!!.startsWith("/")) {
+            if (operationPath.startsWith("/")) {
                 pathPrefix + operationPath
             } else {
                 "$pathPrefix/$operationPath"

--- a/mock/openapi/src/test/resources/openapi3/override-status-code/override-status-code-config.yaml
+++ b/mock/openapi/src/test/resources/openapi3/override-status-code/override-status-code-config.yaml
@@ -26,19 +26,19 @@ resources:
     response:
       statusCode: 201
 
-  - path: "/pets/:petId"
+  - path: "/pets/{petId}"
     method: get
     pathParams:
       petId: 99
     response:
       statusCode: 203
 
-  - path: "/pets/:petId"
+  - path: "/pets/{petId}"
     method: put
     response:
       statusCode: 202
 
-  - path: "/pets/:petId"
+  - path: "/pets/{petId}"
     method: put
     requestHeaders:
       # header key deliberately lowercase in config, but uppercase in request

--- a/mock/rest/src/main/java/io/gatehill/imposter/plugin/rest/RestPluginImpl.kt
+++ b/mock/rest/src/main/java/io/gatehill/imposter/plugin/rest/RestPluginImpl.kt
@@ -45,6 +45,7 @@ package io.gatehill.imposter.plugin.rest
 import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.http.HttpExchange
 import io.gatehill.imposter.http.HttpMethod
+import io.gatehill.imposter.http.HttpRoute
 import io.gatehill.imposter.http.HttpRouter
 import io.gatehill.imposter.http.SingletonResourceMatcher
 import io.gatehill.imposter.http.UniqueRoute
@@ -67,7 +68,6 @@ import io.gatehill.imposter.util.makeFuture
 import io.vertx.core.Vertx
 import org.apache.logging.log4j.LogManager
 import java.util.concurrent.CompletableFuture
-import java.util.regex.Pattern
 import javax.inject.Inject
 
 /**
@@ -165,8 +165,8 @@ open class RestPluginImpl @Inject constructor(
     ): CompletableFuture<Unit> = makeFuture {
         // validate path includes parameter
         val resourcePath = resourceConfig.path ?: ""
-        val matcher = PARAM_MATCHER.matcher(resourcePath)
-        require(matcher.matches()) {
+        val matcher = HttpRoute.PATH_PARAM_PLACEHOLDER.matcher(resourcePath)
+        require(matcher.find()) {
             "Resource '$resourcePath' does not contain a field ID parameter"
         }
 
@@ -201,10 +201,5 @@ open class RestPluginImpl @Inject constructor(
 
     companion object {
         private val LOGGER = LogManager.getLogger(RestPluginImpl::class.java)
-
-        /**
-         * Example: `/anything/:id/something`
-         */
-        private val PARAM_MATCHER = Pattern.compile(".*:(.+).*")
     }
 }

--- a/mock/rest/src/test/resources/config/rest-plugin-config.json
+++ b/mock/rest/src/test/resources/config/rest-plugin-config.json
@@ -3,7 +3,7 @@
   "contentType": "application/json",
   "resources": [
     {
-      "path": "/example/:id",
+      "path": "/example/{id}",
       "type": "ARRAY",
       "response": {
         "staticFile": "rest-plugin-list-data.json"

--- a/server/src/test/resources/capture/test-plugin-config.yaml
+++ b/server/src/test/resources/capture/test-plugin-config.yaml
@@ -2,7 +2,7 @@ plugin: "io.gatehill.imposter.plugin.test.TestPluginImpl"
 
 resources:
 - method: GET
-  path: /users/:userId
+  path: /users/{userId}
   capture:
     userId:
       pathParam: userId
@@ -34,7 +34,7 @@ resources:
     statusCode: 200
 
 - method: PUT
-  path: /users/admins/:userId
+  path: /users/admins/{userId}
   capture:
     # constant value, but dynamic key
     adminUser:
@@ -46,7 +46,7 @@ resources:
     statusCode: 200
 
 - method: PUT
-  path: /defer/:userId
+  path: /defer/{userId}
   capture:
     userId:
       expression: "${context.request.pathParams.userId}"

--- a/server/src/test/resources/prefer-exact-path/test-plugin-config.yaml
+++ b/server/src/test/resources/prefer-exact-path/test-plugin-config.yaml
@@ -3,7 +3,7 @@ plugin: "io.gatehill.imposter.plugin.test.TestPluginImpl"
 resources:
 # Path with placeholder
 - method: GET
-  path: /users/:userId
+  path: /users/{userId}
   response:
     content: "alice"
 

--- a/server/src/test/resources/response-template/test-plugin-config.yaml
+++ b/server/src/test/resources/response-template/test-plugin-config.yaml
@@ -15,7 +15,7 @@ resources:
     template: true
 
 - method: PUT
-  path: /pets/:petId
+  path: /pets/{petId}
   capture:
     petId:
       pathParam: petId


### PR DESCRIPTION
The OpenAPI `{param}` format is more flexible than the Vert.x `:param` format.

Externally we will continue to support both, but using the bracketed format internally fixes a bunch of edge cases around paths with mixed placeholder and string configurations, such as `foo:barbaz` (which in the bracketed format would be `foo{bar}baz`)