### PR TITLE
fix(awslambda): adds failing test case for IllegalStateException when returning 404.

### DIFF
--- a/adapter/awslambda/src/main/java/io/gatehill/imposter/awslambda/impl/model/LambdaHttpExchange.kt
+++ b/adapter/awslambda/src/main/java/io/gatehill/imposter/awslambda/impl/model/LambdaHttpExchange.kt
@@ -44,12 +44,7 @@
 package io.gatehill.imposter.awslambda.impl.model
 
 import com.google.common.base.Strings
-import io.gatehill.imposter.http.ExchangePhase
-import io.gatehill.imposter.http.HttpExchange
-import io.gatehill.imposter.http.HttpRequest
-import io.gatehill.imposter.http.HttpResponse
-import io.gatehill.imposter.http.HttpRoute
-import io.gatehill.imposter.http.HttpRouter
+import io.gatehill.imposter.http.*
 import io.gatehill.imposter.util.HttpUtil
 import io.vertx.core.buffer.Buffer
 
@@ -61,9 +56,14 @@ class LambdaHttpExchange(
     override val currentRoute: HttpRoute?,
     override val request: HttpRequest,
     response: HttpResponse,
+
+    /**
+     * Externally manage the lifecycle of attributes so they persist between exchange
+     * instances for the same request/response pair.
+     */
+    private val attributes : MutableMap<String, Any>,
 ) : HttpExchange {
     override var phase = ExchangePhase.REQUEST_RECEIVED
-    private val attributes = mutableMapOf<String, Any>()
 
     override var failureCause: Throwable? = null
         private set

--- a/adapter/awslambda/src/test/java/io/gatehill/imposter/awslambda/Handled404Test.kt
+++ b/adapter/awslambda/src/test/java/io/gatehill/imposter/awslambda/Handled404Test.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * This file is part of Imposter.
+ *
+ * "Commons Clause" License Condition v1.0
+ *
+ * The Software is provided to you by the Licensor under the License, as
+ * defined below, subject to the following condition.
+ *
+ * Without limiting other conditions in the License, the grant of rights
+ * under the License will not include, and the License does not grant to
+ * you, the right to Sell the Software.
+ *
+ * For purposes of the foregoing, "Sell" means practicing any or all of
+ * the rights granted to you under the License to provide to third parties,
+ * for a fee or other consideration (including without limitation fees for
+ * hosting or consulting/support services related to the Software), a
+ * product or service whose value derives, entirely or substantially, from
+ * the functionality of the Software. Any license notice or attribution
+ * required by the License must also include this Commons Clause License
+ * Condition notice.
+ *
+ * Software: Imposter
+ *
+ * License: GNU Lesser General Public License version 3
+ *
+ * Licensor: Peter Cornish
+ *
+ * Imposter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Imposter is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Imposter.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.gatehill.imposter.awslambda
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent
+import com.amazonaws.services.lambda.runtime.tests.annotations.Event
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+
+/**
+ * Test event handling for requests with queries.
+ */
+class Handled404Test : AbstractHandlerTest() {
+    private var handlerV1: Handler? = null
+    private var handlerV2: HandlerV2? = null
+
+    override val configDir = "/handled-404/config"
+
+    @BeforeEach
+    fun setUp() {
+        configure()
+        handlerV1 = Handler()
+        handlerV2 = HandlerV2()
+    }
+
+    @ParameterizedTest
+    @Event(value = "handled-404/requests_v1/request.json", type = APIGatewayProxyRequestEvent::class)
+    fun `v1 request returning 404`(event: APIGatewayProxyRequestEvent) {
+        val responseEvent = handlerV1!!.handleRequest(event, context!!)
+
+        assertNotNull(responseEvent, "Response event should be returned")
+        assertEquals(404, responseEvent.statusCode)
+        assertEquals("Not Found", responseEvent.body)
+    }
+
+    @ParameterizedTest
+    @Event(value = "handled-404/requests_v2/request.json", type = APIGatewayV2HTTPEvent::class)
+    fun `v2 request returning 404`(event: APIGatewayV2HTTPEvent) {
+        val responseEvent = handlerV2!!.handleRequest(event, context!!)
+
+        assertNotNull(responseEvent, "Response event should be returned")
+        assertEquals(404, responseEvent.statusCode)
+        assertEquals("Not Found", responseEvent.body)
+    }
+}

--- a/adapter/awslambda/src/test/resources/handled-404/config/mock-config.yaml
+++ b/adapter/awslambda/src/test/resources/handled-404/config/mock-config.yaml
@@ -1,0 +1,8 @@
+plugin: rest
+
+resources:
+  - method: GET
+    path: /notfound
+    response:
+      statusCode: 404
+      content: Not Found

--- a/adapter/awslambda/src/test/resources/handled-404/requests_v1/request.json
+++ b/adapter/awslambda/src/test/resources/handled-404/requests_v1/request.json
@@ -1,0 +1,9 @@
+{
+  "path": "/notfound",
+  "httpMethod":  "GET",
+  "headers": {},
+  "queryStringParameters": {},
+  "pathParameters": {},
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/adapter/awslambda/src/test/resources/handled-404/requests_v2/request.json
+++ b/adapter/awslambda/src/test/resources/handled-404/requests_v2/request.json
@@ -1,0 +1,13 @@
+{
+  "headers": {},
+  "queryStringParameters": {},
+  "pathParameters": {},
+  "body": null,
+  "isBase64Encoded": false,
+  "requestContext": {
+    "http": {
+      "path": "/notfound",
+      "method":  "GET"
+    }
+  }
+}

--- a/adapter/awslambda/src/test/resources/request-with-query/requests_v1/request_with_query.json
+++ b/adapter/awslambda/src/test/resources/request-with-query/requests_v1/request_with_query.json
@@ -5,9 +5,7 @@
   "queryStringParameters": {
     "foo": "bar"
   },
-  "pathParameters": {
-    "petId": "2"
-  },
+  "pathParameters": {},
   "body": null,
   "isBase64Encoded": false
 }

--- a/adapter/awslambda/src/test/resources/request-with-query/requests_v2/request_with_query.json
+++ b/adapter/awslambda/src/test/resources/request-with-query/requests_v2/request_with_query.json
@@ -3,9 +3,7 @@
   "queryStringParameters": {
     "foo": "bar"
   },
-  "pathParameters": {
-    "petId": "2"
-  },
+  "pathParameters": {},
   "body": null,
   "isBase64Encoded": false,
   "requestContext": {

--- a/core/engine/src/main/java/io/gatehill/imposter/service/HandlerServiceImpl.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/service/HandlerServiceImpl.kt
@@ -46,13 +46,7 @@ import com.google.common.collect.Lists
 import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.config.ResolvedResourceConfig
 import io.gatehill.imposter.config.util.EnvVars
-import io.gatehill.imposter.http.ExchangePhase
-import io.gatehill.imposter.http.HttpExchange
-import io.gatehill.imposter.http.HttpExchangeFutureHandler
-import io.gatehill.imposter.http.HttpExchangeHandler
-import io.gatehill.imposter.http.HttpMethod
-import io.gatehill.imposter.http.HttpRouter
-import io.gatehill.imposter.http.ResourceMatcher
+import io.gatehill.imposter.http.*
 import io.gatehill.imposter.lifecycle.SecurityLifecycleHooks
 import io.gatehill.imposter.lifecycle.SecurityLifecycleListener
 import io.gatehill.imposter.plugin.config.InterceptorsHolder
@@ -73,7 +67,7 @@ import kotlinx.coroutines.future.future
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.LogManager
 import java.io.File
-import java.util.UUID
+import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.regex.Pattern
 import javax.inject.Inject
@@ -155,6 +149,8 @@ class HandlerServiceImpl @Inject constructor(
             httpExchange.get<Boolean>(ResourceUtil.RC_SEND_NOT_FOUND_RESPONSE) == true
         ) {
             // only override response processing if the 404 did not originate from the mock engine
+            // otherwise this will attempt to send a duplicate response to an already completed
+            // exchange, resulting in an IllegalStateException
             logAppropriatelyForPath(httpExchange, "File not found")
             responseService.sendNotFoundResponse(httpExchange)
         }


### PR DESCRIPTION
fixes #633 

The 404 status emitted by the plugin is being caught by the default 'not found' handler in the Lambda implementation, which is trying to handle a request that's already been responded to. This'll need a new release to fix, once we have one.