### PR TITLE
feat(soap): adds support for returning SOAP faults

### DIFF
--- a/core/api/src/main/java/io/gatehill/imposter/script/MutableResponseBehaviour.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/script/MutableResponseBehaviour.kt
@@ -54,7 +54,6 @@ interface MutableResponseBehaviour {
     @Deprecated("Use withContent(String) instead", replaceWith = ReplaceWith("withContent"))
     fun withData(responseData: String?) = withContent(responseData)
     fun template(): MutableResponseBehaviour
-    fun withExampleName(exampleName: String): MutableResponseBehaviour
     fun usingDefaultBehaviour(): MutableResponseBehaviour
     fun skipDefaultBehaviour(): MutableResponseBehaviour
     fun continueToNext(): MutableResponseBehaviour
@@ -68,6 +67,16 @@ interface MutableResponseBehaviour {
      */
     fun withFailure(failureType: String): MutableResponseBehaviour
     fun withFailureType(failureType: FailureSimulationType?): MutableResponseBehaviour
+
+    /**
+     * Only supported for OpenAPI plugin.
+     */
+    fun withExampleName(exampleName: String): MutableResponseBehaviour
+
+    /**
+     * Only supported for SOAP plugin.
+     */
+    fun withSoapFault(): MutableResponseBehaviour
 
     @Deprecated("Use skipDefaultBehaviour() instead", ReplaceWith("skipDefaultBehaviour()"))
     fun immediately(): MutableResponseBehaviour

--- a/core/api/src/main/java/io/gatehill/imposter/script/ReadWriteResponseBehaviourImpl.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/script/ReadWriteResponseBehaviourImpl.kt
@@ -51,11 +51,12 @@ open class ReadWriteResponseBehaviourImpl : ReadWriteResponseBehaviour {
     override var responseFile: String? = null
     override var content: String? = null
     override var isTemplate = false
-    override var exampleName: String? = null
     override val responseHeaders: MutableMap<String, String> = mutableMapOf()
     private var behaviourConfigured = false
     override var performanceSimulation: PerformanceSimulationConfig? = null
     override var failureType: FailureSimulationType? = null
+    override var exampleName: String? = null
+    override var soapFault: Boolean = false
 
     override fun template(): MutableResponseBehaviour {
         isTemplate = true
@@ -105,11 +106,6 @@ open class ReadWriteResponseBehaviourImpl : ReadWriteResponseBehaviour {
 
     override fun withContent(content: String?): MutableResponseBehaviour {
         this.content = content
-        return this
-    }
-
-    override fun withExampleName(exampleName: String): MutableResponseBehaviour {
-        this.exampleName = exampleName
         return this
     }
 
@@ -203,6 +199,17 @@ open class ReadWriteResponseBehaviourImpl : ReadWriteResponseBehaviour {
 
     override fun withFailureType(failureType: FailureSimulationType?): MutableResponseBehaviour {
         this.failureType = failureType
+        return this
+    }
+
+    override fun withExampleName(exampleName: String): MutableResponseBehaviour {
+        this.exampleName = exampleName
+        return this
+    }
+
+    override fun withSoapFault(): MutableResponseBehaviour {
+        this.soapFault = true
+        withStatusCode(500)
         return this
     }
 }

--- a/core/api/src/main/java/io/gatehill/imposter/script/ResponseBehaviour.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/script/ResponseBehaviour.kt
@@ -51,8 +51,17 @@ interface ResponseBehaviour {
     val responseFile: String?
     val content: String?
     val isTemplate: Boolean
-    val exampleName: String?
     val behaviourType: ResponseBehaviourType?
     val performanceSimulation: PerformanceSimulationConfig?
     val failureType: FailureSimulationType?
+
+    /**
+     * Only supported for OpenAPI plugin.
+     */
+    val exampleName: String?
+
+    /**
+     * Only supported for SOAP plugin.
+     */
+    val soapFault: Boolean
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,7 @@ response:
     X-Custom-Header: foo
 ```
 
-A few things to call out:
+Some highlights:
 
 - This endpoint will only be accessible via the `POST` HTTP method
 - We've indicated that status code 201 should be returned

--- a/docs/openapi_plugin.md
+++ b/docs/openapi_plugin.md
@@ -94,7 +94,7 @@ definitions:
         type: "string"
 ```
 
-A few things to call out:
+Some highlights:
 
 * We’ve defined the endpoint `/pets` as expecting an HTTP GET request
 * We’ve said it will produce JSON responses

--- a/docs/rest_plugin.md
+++ b/docs/rest_plugin.md
@@ -81,7 +81,7 @@ We can configure different responses at multiple paths as follows:
         response:
           file: dogs.json
 
-A few things to call out:
+Some highlights:
 
 * We’ve defined the endpoint `/cats` to return the contents of our sample JSON file; in other words an array of cats.
 * We’ve also said that, because the response file is a JSON array, we want to allow querying of individual items by their ID, under the `/cats/{id}` endpoint.

--- a/docs/soap_plugin.md
+++ b/docs/soap_plugin.md
@@ -225,7 +225,13 @@ HTTP/1.1 400 Bad Request
 
 ## Returning fault messages
 
-If your WSDL document defines a `fault`, then Imposter can generate a sample response from its type. To return a fault, set the response status code to 500.
+If your WSDL document defines a `fault`, then Imposter can generate a sample response from its type.
+
+To return a fault you can:
+
+1. set the response status code to `500`, or
+2. set the `response.soapFault` configuration property to `true`, or
+3. use the `respond().withSoapFault()` script function
 
 ### Example configuration to respond with a fault
 
@@ -241,7 +247,8 @@ resources:
 ```
 
 > **Tip**
-> Use conditional matching with resources, to only return a fault in particular circumstances. 
+> Use conditional matching with resources, to only return a fault in particular circumstances.
+> See [fault-example](https://github.com/outofcoffee/imposter/blob/main/examples/soap/fault-example) for an example of how to do this.
 
 ## Scripted responses (advanced)
 
@@ -312,6 +319,7 @@ Now, `example.groovy` can control the responses, such as:
 
 - [conditional-example](https://github.com/outofcoffee/imposter/blob/main/examples/soap/conditional-example)
 - [scripted-example](https://github.com/outofcoffee/imposter/blob/main/examples/soap/scripted-example)
+- [fault-example](https://github.com/outofcoffee/imposter/blob/main/examples/soap/fault-example)
 
 ### Configuration reference
 

--- a/examples/soap/fault-example/README.md
+++ b/examples/soap/fault-example/README.md
@@ -1,0 +1,68 @@
+# Return a SOAP fault
+
+This example returns a SOAP fault if the `id` in the request message is `10`.
+
+Start mock server:
+
+```bash
+imposter up
+```
+
+Send request:
+
+```bash
+curl --data '<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+  <env:Header/>
+  <env:Body>
+    <getPetByIdRequest xmlns="urn:com:example:petstore">
+      <id>10</id>
+    </getPetByIdRequest>
+  </env:Body>
+</env:Envelope>' http://localhost:8080/pets/
+```
+
+Response:
+
+```xml
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+    <env:Header/>
+    <env:Body>
+        <urn:getPetFault xmlns:urn="urn:com:example:petstore">
+            <code>3</code>
+            <description>string</description>
+        </urn:getPetFault>
+    </env:Body>
+</env:Envelope>
+```
+
+## Notes
+
+This example uses conditional matching with resources to only return a fault under specific conditions.
+
+If a non-matching `id` is sent in the request, the default response message is generated:
+
+```bash
+curl --data '<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+  <env:Header/>
+  <env:Body>
+    <getPetByIdRequest xmlns="urn:com:example:petstore">
+      <id>3</id>
+    </getPetByIdRequest>
+  </env:Body>
+</env:Envelope>' http://localhost:8080/pets/
+```
+
+Response:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"> 
+  <env:Header/>
+  <env:Body>
+    <urn:getPetByIdResponse xmlns:urn="urn:com:example:petstore">
+      <id>3</id>
+      <name>string</name>
+    </urn:getPetByIdResponse>
+  </env:Body>
+</env:Envelope>
+```

--- a/examples/soap/fault-example/imposter-config.yaml
+++ b/examples/soap/fault-example/imposter-config.yaml
@@ -1,0 +1,14 @@
+plugin: soap
+wsdlFile: service.wsdl
+
+resources:
+  - binding: SoapBinding
+    operation: getPetById
+    requestBody:
+      xPath: "/env:Envelope/env:Body/pets:getPetByIdRequest/pets:id"
+      value: "10"
+      xmlNamespaces:
+        env: "http://www.w3.org/2003/05/soap-envelope"
+        pets: "urn:com:example:petstore"
+    response:
+      statusCode: 500

--- a/examples/soap/fault-example/service.wsdl
+++ b/examples/soap/fault-example/service.wsdl
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<definitions name="PetService" xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:tns="urn:com:example:petstore"
+             xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+             xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+             targetNamespace="urn:com:example:petstore">
+
+    <documentation>
+        A pet store service with a single operation and SOAP binding.
+    </documentation>
+
+    <types>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                   xmlns="urn:com:example:petstore"
+                   targetNamespace="urn:com:example:petstore">
+
+            <xs:complexType name="petType">
+                <xs:all>
+                    <xs:element name="id" type="xs:int"/>
+                    <xs:element name="name" type="xs:string"/>
+                </xs:all>
+            </xs:complexType>
+
+            <xs:complexType name="getPetByIdRequest">
+                <xs:all>
+                    <xs:element name="id" type="xs:int"/>
+                </xs:all>
+            </xs:complexType>
+
+            <xs:complexType name="fault">
+                <xs:all>
+                    <xs:element name="code" type="xs:int" />
+                    <xs:element name="description" type="xs:string" />
+                </xs:all>
+            </xs:complexType>
+
+            <xs:element name="getPetByIdRequest" type="getPetByIdRequest"/>
+            <xs:element name="getPetByIdResponse" type="petType"/>
+            <xs:element name="getPetFault" type="fault"/>
+        </xs:schema>
+    </types>
+
+    <message name="getPetByIdRequest">
+        <part element="tns:getPetByIdRequest" name="parameters"/>
+    </message>
+    <message name="getPetByIdResponse">
+        <part element="tns:getPetByIdResponse" name="parameters"/>
+    </message>
+    <message name="getPetFault">
+        <part element="tns:getPetFault" name="parameters"/>
+    </message>
+
+    <portType name="PetPortType">
+        <operation name="getPetById">
+            <input message="tns:getPetByIdRequest" name="getPetByIdRequest"/>
+            <output message="tns:getPetByIdResponse" name="getPetByIdResponse"/>
+            <fault message="tns:getPetFault" name="getPetFault" />
+        </operation>
+    </portType>
+
+    <binding name="SoapBinding" type="tns:PetPortType">
+        <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/soap"/>
+
+        <operation name="getPetById">
+            <soap12:operation soapAction="getPetById" style="document"/>
+            <input name="getPetByIdRequest">
+                <soap12:body use="literal"/>
+            </input>
+            <output name="getPetByIdResponse">
+                <soap12:body use="literal"/>
+            </output>
+            <fault name="getPetFault">
+                <soap12:body use="literal"/>
+            </fault>
+        </operation>
+    </binding>
+
+    <service name="PetService">
+        <port name="SoapEndpoint" binding="tns:SoapBinding">
+            <soap12:address location="http://www.example.com/pets/"/>
+        </port>
+    </service>
+</definitions>

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/config/SoapPluginConfig.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/config/SoapPluginConfig.kt
@@ -62,7 +62,10 @@ class SoapPluginConfig : CommonPluginConfig(), ResourcesHolder<SoapPluginResourc
     @JsonProperty("envelope")
     val envelope: Boolean = true
 
+    @JsonProperty("response")
+    override val responseConfig = SoapResponseConfig()
+
     override fun toString(): String {
-        return "SoapPluginConfig(parent=${super.toString()}, wsdlFile=$wsdlFile, resources=$resources, isDefaultsFromRootResponse=$isDefaultsFromRootResponse, envelope=$envelope)"
+        return "SoapPluginConfig(parent=${super.toString()}, wsdlFile=$wsdlFile, resources=$resources, isDefaultsFromRootResponse=$isDefaultsFromRootResponse, envelope=$envelope, responseConfig=$responseConfig)"
     }
 }

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/config/SoapPluginResourceConfig.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/config/SoapPluginResourceConfig.kt
@@ -49,9 +49,11 @@ import io.gatehill.imposter.plugin.config.resource.AbstractResourceConfig
 import io.gatehill.imposter.plugin.config.resource.EvalResourceConfig
 import io.gatehill.imposter.plugin.config.resource.request.RequestBodyConfig
 import io.gatehill.imposter.plugin.config.resource.request.RequestBodyResourceConfig
+import io.gatehill.imposter.plugin.config.steps.StepConfig
+import io.gatehill.imposter.plugin.config.steps.StepsConfigHolder
 import java.util.*
 
-class SoapPluginResourceConfig : AbstractResourceConfig(), RequestBodyResourceConfig, EvalResourceConfig {
+class SoapPluginResourceConfig : AbstractResourceConfig(), RequestBodyResourceConfig, EvalResourceConfig, StepsConfigHolder {
     @JsonProperty("binding")
     val binding: String? = null
 
@@ -66,6 +68,12 @@ class SoapPluginResourceConfig : AbstractResourceConfig(), RequestBodyResourceCo
 
     @field:JsonProperty("eval")
     override var eval: String? = null
+
+    @field:JsonProperty("steps")
+    override val steps: List<StepConfig>? = null
+
+    @JsonProperty("response")
+    override val responseConfig = SoapResponseConfig()
 
     @get:JsonIgnore
     override val resourceId by lazy { UUID.randomUUID().toString() }

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/config/SoapResponseConfig.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/config/SoapResponseConfig.kt
@@ -40,30 +40,23 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Imposter.  If not, see <https://www.gnu.org/licenses/>.
  */
-package io.gatehill.imposter.plugin.openapi.http
+package io.gatehill.imposter.plugin.soap.config
 
-import com.google.common.base.Strings
-import io.gatehill.imposter.http.DefaultResponseBehaviourFactory
-import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
-import io.gatehill.imposter.plugin.openapi.config.OpenApiResponseConfig
-import io.gatehill.imposter.script.ReadWriteResponseBehaviour
+import io.gatehill.imposter.plugin.config.resource.ResponseConfig
 
 /**
- * Extends base response behaviour population with specific
- * OpenAPI plugin configuration.
+ * Extends the base response configuration with items specific
+ * to the OpenAPI plugin.
  *
  * @author Pete Cornish
  */
-class OpenApiResponseBehaviourFactory : DefaultResponseBehaviourFactory() {
-    override fun populate(
-        statusCode: Int,
-        resourceConfig: BasicResourceConfig,
-        responseBehaviour: ReadWriteResponseBehaviour
-    ) {
-        super.populate(statusCode, resourceConfig, responseBehaviour)
-        val configExampleName = (resourceConfig.responseConfig as OpenApiResponseConfig).exampleName
-        if (Strings.isNullOrEmpty(responseBehaviour.exampleName) && !Strings.isNullOrEmpty(configExampleName)) {
-            responseBehaviour.withExampleName(configExampleName!!)
-        }
+class SoapResponseConfig : ResponseConfig() {
+    val soapFault: Boolean? = null
+
+    override fun hasConfiguration(): Boolean =
+        super.hasConfiguration() || null != soapFault
+
+    override fun toString(): String {
+        return "OpenApiResponseConfig(parent=${super.toString()}, soapFault=$soapFault)"
     }
 }

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/http/SoapResponseBehaviourFactory.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/http/SoapResponseBehaviourFactory.kt
@@ -40,30 +40,31 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Imposter.  If not, see <https://www.gnu.org/licenses/>.
  */
-package io.gatehill.imposter.plugin.openapi.http
+package io.gatehill.imposter.plugin.soap.http
 
-import com.google.common.base.Strings
 import io.gatehill.imposter.http.DefaultResponseBehaviourFactory
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
-import io.gatehill.imposter.plugin.openapi.config.OpenApiResponseConfig
+import io.gatehill.imposter.plugin.soap.config.SoapResponseConfig
 import io.gatehill.imposter.script.ReadWriteResponseBehaviour
 
 /**
  * Extends base response behaviour population with specific
- * OpenAPI plugin configuration.
+ * SOAP plugin configuration.
  *
  * @author Pete Cornish
  */
-class OpenApiResponseBehaviourFactory : DefaultResponseBehaviourFactory() {
+class SoapResponseBehaviourFactory : DefaultResponseBehaviourFactory() {
     override fun populate(
         statusCode: Int,
         resourceConfig: BasicResourceConfig,
         responseBehaviour: ReadWriteResponseBehaviour
     ) {
-        super.populate(statusCode, resourceConfig, responseBehaviour)
-        val configExampleName = (resourceConfig.responseConfig as OpenApiResponseConfig).exampleName
-        if (Strings.isNullOrEmpty(responseBehaviour.exampleName) && !Strings.isNullOrEmpty(configExampleName)) {
-            responseBehaviour.withExampleName(configExampleName!!)
+        if ((resourceConfig.responseConfig as SoapResponseConfig).soapFault == true) {
+            responseBehaviour.withSoapFault()
         }
+
+        // invoke superclass after calling `withSoapFault` as it
+        // overrides the status code to 500
+        super.populate(statusCode, resourceConfig, responseBehaviour)
     }
 }

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/model/WsdlModel.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/model/WsdlModel.kt
@@ -81,4 +81,5 @@ data class WsdlOperation(
     val style: String?,
     val inputRef: OperationMessage?,
     val outputRef: OperationMessage?,
+    val faultRef: OperationMessage?,
 )

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/Wsdl2Parser.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/parser/Wsdl2Parser.kt
@@ -152,7 +152,7 @@ class Wsdl2Parser(
             expressionTemplate = "./wsdl:operation[@name='%s']",
             name = operationName
         )
-        return operation?.let { parseOperation(operationName, operation) }
+        return operation?.let { parseOperation(operationName, interfaceNode, operation) }
     }
 
     private fun getInterfaceNode(interfaceName: String): Element? {
@@ -163,13 +163,16 @@ class Wsdl2Parser(
         )
     }
 
-    private fun parseOperation(operationName: String, operation: Element): WsdlOperation {
+    private fun parseOperation(operationName: String, iface: Element, operation: Element): WsdlOperation {
         val soapOperation = selectSingleNode(operation, "./soap:operation") ?: throw IllegalStateException(
             "Unable to find soap:operation for operation $operationName"
         )
         val input = getMessage(operation, "./wsdl:input", required = true)
         val output = getMessage(operation, "./wsdl:output", required = true)
+
+        // fall back to fault defined at interface level
         val fault = getMessage(operation, "./wsdl:fault", required = false)
+            ?: getMessage(iface, "./wsdl:fault", required = false)
 
         return WsdlOperation(
             name = operation.getAttributeValue("name"),

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/service/SoapExampleService.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/service/SoapExampleService.kt
@@ -77,39 +77,28 @@ class SoapExampleService {
         schemaContext: SchemaContext,
         service: WsdlService,
         operation: WsdlOperation,
+        message: OperationMessage,
         bodyHolder: MessageBodyHolder,
     ): Boolean {
         logger.debug("Generating response example for operation: {} in service: {}", operation.name, service.name)
         val example = when (operation.style) {
-            SoapUtil.OPERATION_STYLE_DOCUMENT -> generateDocumentResponse(schemaContext, service, operation)
-            SoapUtil.OPERATION_STYLE_RPC -> generateRpcResponse(schemaContext, service, operation)
+            SoapUtil.OPERATION_STYLE_DOCUMENT -> generateDocumentMessage(schemaContext, service, message)
+            SoapUtil.OPERATION_STYLE_RPC -> generateRpcResponse(schemaContext, service, operation, message)
             else -> throw UnsupportedOperationException("Unsupported operation style: ${operation.style}")
         }
         transmitExample(httpExchange, example, bodyHolder)
         return true
     }
 
-    private fun generateDocumentResponse(
-        schemaContext: SchemaContext,
-        service: WsdlService,
-        operation: WsdlOperation,
-    ): String {
-        return operation.outputRef?.let { message ->
-            generateDocumentMessage(schemaContext, service, message)
-
-        } ?: throw IllegalStateException(
-            "No output message for operation: $operation"
-        )
-    }
-
     private fun generateRpcResponse(
         schemaContext: SchemaContext,
         service: WsdlService,
         operation: WsdlOperation,
+        message: OperationMessage,
     ): String {
         // by convention, the suffix 'Response' is added to the operation name
         val rootElementName = operation.name + "Response"
-        val parts = operation.outputRef?.let { listOf(it) } ?: emptyList()
+        val parts = listOf(message)
         return generateWrappedResponse(schemaContext, service, rootElementName, parts)
     }
 

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/FaultExampleTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/FaultExampleTest.kt
@@ -70,11 +70,71 @@ class FaultExampleTest : BaseVerticleTest() {
     }
 
     @Test
-    fun `respond with a fault generated from the schema`() {
+    fun `respond with a fault generated from the schema if status is 500`() {
         val getPetByIdEnv = SoapUtil.wrapInEnv(
             """
 <getPetByIdRequest xmlns="urn:com:example:petstore">
   <id>10</id>
+</getPetByIdRequest>
+""".trim(), soapEnvNamespace
+        )
+
+        RestAssured.given()
+            .log().ifValidationFails()
+            .accept(soapContentType)
+            .contentType(soapContentType)
+            .`when`()
+            .body(getPetByIdEnv)
+            .post("/pets/")
+            .then()
+            .log().ifValidationFails()
+            .statusCode(HttpUtil.HTTP_INTERNAL_ERROR)
+            .body(
+                Matchers.allOf(
+                    Matchers.containsString("Envelope"),
+                    Matchers.containsString("getPetFault"),
+                    Matchers.containsString("code"),
+                    Matchers.containsString("description"),
+                )
+            )
+    }
+
+    @Test
+    fun `respond with a fault generated from the schema if response configuration set`() {
+        val getPetByIdEnv = SoapUtil.wrapInEnv(
+            """
+<getPetByIdRequest xmlns="urn:com:example:petstore">
+  <id>99</id>
+</getPetByIdRequest>
+""".trim(), soapEnvNamespace
+        )
+
+        RestAssured.given()
+            .log().ifValidationFails()
+            .accept(soapContentType)
+            .contentType(soapContentType)
+            .`when`()
+            .body(getPetByIdEnv)
+            .post("/pets/")
+            .then()
+            .log().ifValidationFails()
+            .statusCode(HttpUtil.HTTP_INTERNAL_ERROR)
+            .body(
+                Matchers.allOf(
+                    Matchers.containsString("Envelope"),
+                    Matchers.containsString("getPetFault"),
+                    Matchers.containsString("code"),
+                    Matchers.containsString("description"),
+                )
+            )
+    }
+
+    @Test
+    fun `respond with a fault generated from the schema if script function called`() {
+        val getPetByIdEnv = SoapUtil.wrapInEnv(
+            """
+<getPetByIdRequest xmlns="urn:com:example:petstore">
+  <id>100</id>
 </getPetByIdRequest>
 """.trim(), soapEnvNamespace
         )

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/FaultExampleTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/FaultExampleTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * This file is part of Imposter.
+ *
+ * "Commons Clause" License Condition v1.0
+ *
+ * The Software is provided to you by the Licensor under the License, as
+ * defined below, subject to the following condition.
+ *
+ * Without limiting other conditions in the License, the grant of rights
+ * under the License will not include, and the License does not grant to
+ * you, the right to Sell the Software.
+ *
+ * For purposes of the foregoing, "Sell" means practicing any or all of
+ * the rights granted to you under the License to provide to third parties,
+ * for a fee or other consideration (including without limitation fees for
+ * hosting or consulting/support services related to the Software), a
+ * product or service whose value derives, entirely or substantially, from
+ * the functionality of the Software. Any license notice or attribution
+ * required by the License must also include this Commons Clause License
+ * Condition notice.
+ *
+ * Software: Imposter
+ *
+ * License: GNU Lesser General Public License version 3
+ *
+ * Licensor: Peter Cornish
+ *
+ * Imposter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Imposter is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Imposter.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.gatehill.imposter.plugin.soap
+
+import io.gatehill.imposter.plugin.soap.util.SoapUtil
+import io.gatehill.imposter.server.BaseVerticleTest
+import io.gatehill.imposter.util.HttpUtil
+import io.restassured.RestAssured
+import io.vertx.ext.unit.TestContext
+import org.hamcrest.Matchers
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [SoapPluginImpl] generation of fault responses.
+ *
+ * @author Pete Cornish
+ */
+class FaultExampleTest : BaseVerticleTest() {
+    override val pluginClass = SoapPluginImpl::class.java
+    override val testConfigDirs = listOf("/fault-example")
+    private val soapEnvNamespace = SoapUtil.soap12RecEnvNamespace
+    private val soapContentType = SoapUtil.soap12ContentType
+
+    @Before
+    @Throws(Exception::class)
+    override fun setUp(testContext: TestContext) {
+        super.setUp(testContext)
+        RestAssured.baseURI = "http://$host:$listenPort"
+    }
+
+    @Test
+    fun `respond with a fault generated from the schema`() {
+        val getPetByIdEnv = SoapUtil.wrapInEnv(
+            """
+<getPetByIdRequest xmlns="urn:com:example:petstore">
+  <id>10</id>
+</getPetByIdRequest>
+""".trim(), soapEnvNamespace
+        )
+
+        RestAssured.given()
+            .log().ifValidationFails()
+            .accept(soapContentType)
+            .contentType(soapContentType)
+            .`when`()
+            .body(getPetByIdEnv)
+            .post("/pets/")
+            .then()
+            .log().ifValidationFails()
+            .statusCode(HttpUtil.HTTP_INTERNAL_ERROR)
+            .body(
+                Matchers.allOf(
+                    Matchers.containsString("Envelope"),
+                    Matchers.containsString("getPetFault"),
+                    Matchers.containsString("code"),
+                    Matchers.containsString("description"),
+                )
+            )
+    }
+}

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Soap11ParserTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Soap11ParserTest.kt
@@ -86,7 +86,7 @@ class Wsdl1Soap11ParserTest {
     }
 
     @Test
-    fun getBinding() {
+    fun `get SOAP binding, getPetById operation`() {
         val binding = parser.getBinding("SoapBinding")
         assertNotNull("SoapBinding should not be null", binding)
 
@@ -102,7 +102,10 @@ class Wsdl1Soap11ParserTest {
         operation!!
         assertEquals("getPetById", operation.name)
         assertEquals("getPetById", operation.soapAction)
+
+        // operation style defined at operation level in this service
         assertEquals("document", operation.style)
+
         assertEquals(
             QName("urn:com:example:petstore", "getPetByIdRequest"),
             (operation.inputRef as ElementOperationMessage).elementName,
@@ -111,11 +114,45 @@ class Wsdl1Soap11ParserTest {
             QName("urn:com:example:petstore", "getPetByIdResponse"),
             (operation.outputRef as ElementOperationMessage).elementName,
         )
+        assertEquals(
+            QName("urn:com:example:petstore", "getPetFault"),
+            (operation.faultRef as ElementOperationMessage?)?.elementName,
+        )
+    }
+
+    @Test
+    fun `get HTTP binding, getPetByName operation`() {
+        val binding = parser.getBinding("HttpBinding")
+        assertNotNull("HttpBinding should not be null", binding)
+
+        binding!!
+        assertEquals("HttpBinding", binding.name)
+        assertEquals(BindingType.HTTP, binding.type)
+        assertEquals("tns:PetPortType", binding.interfaceRef)
+
+        assertEquals(2, binding.operations.size)
+        val operation = binding.operations.find { it.name == "getPetByName" }
+        assertNotNull("getPetByName operation should not be null", operation)
+
+        operation!!
+        assertEquals("getPetByName", operation.name)
+        assertEquals("getPetByName", operation.soapAction)
 
         // operation style should fall back to binding style in WSDL 1.x
-        val petNameOp = binding.operations.find { it.name == "getPetByName" }
-        assertNotNull(petNameOp)
-        assertEquals("document", petNameOp?.style)
+        assertEquals("document", operation.style)
+
+        assertEquals(
+            QName("urn:com:example:petstore", "getPetByNameRequest"),
+            (operation.inputRef as ElementOperationMessage).elementName,
+        )
+        assertEquals(
+            QName("urn:com:example:petstore", "getPetByNameResponse"),
+            (operation.outputRef as ElementOperationMessage).elementName,
+        )
+        assertEquals(
+            QName("urn:com:example:petstore", "getPetFault"),
+            (operation.faultRef as ElementOperationMessage?)?.elementName,
+        )
     }
 
     @Test

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Soap12ParserTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Soap12ParserTest.kt
@@ -86,7 +86,7 @@ class Wsdl1Soap12ParserTest {
     }
 
     @Test
-    fun getBinding() {
+    fun `get SOAP binding, getPetById operation`() {
         val binding = parser.getBinding("SoapBinding")
         assertNotNull("SoapBinding should not be null", binding)
 
@@ -102,7 +102,10 @@ class Wsdl1Soap12ParserTest {
         operation!!
         assertEquals("getPetById", operation.name)
         assertEquals("getPetById", operation.soapAction)
+
+        // operation style defined at operation level in this service
         assertEquals("document", operation.style)
+
         assertEquals(
             QName("urn:com:example:petstore","getPetByIdRequest"),
             (operation.inputRef as ElementOperationMessage).elementName,
@@ -111,11 +114,45 @@ class Wsdl1Soap12ParserTest {
             QName("urn:com:example:petstore","getPetByIdResponse"),
             (operation.outputRef as ElementOperationMessage).elementName,
         )
+        assertEquals(
+            QName("urn:com:example:petstore", "getPetFault"),
+            (operation.faultRef as ElementOperationMessage?)?.elementName,
+        )
+    }
+
+    @Test
+    fun `get HTTP binding, getPetByName operation`() {
+        val binding = parser.getBinding("HttpBinding")
+        assertNotNull("HttpBinding should not be null", binding)
+
+        binding!!
+        assertEquals("HttpBinding", binding.name)
+        assertEquals(BindingType.HTTP, binding.type)
+        assertEquals("tns:PetPortType", binding.interfaceRef)
+
+        assertEquals(2, binding.operations.size)
+        val operation = binding.operations.find { it.name == "getPetByName" }
+        assertNotNull("getPetByName operation should not be null", operation)
+
+        operation!!
+        assertEquals("getPetByName", operation.name)
+        assertEquals("getPetByName", operation.soapAction)
 
         // operation style should fall back to binding style in WSDL 1.x
-        val petNameOp = binding.operations.find { it.name == "getPetByName" }
-        assertNotNull(petNameOp)
-        assertEquals("document", petNameOp?.style)
+        assertEquals("document", operation.style)
+
+        assertEquals(
+            QName("urn:com:example:petstore","getPetByNameRequest"),
+            (operation.inputRef as ElementOperationMessage).elementName,
+        )
+        assertEquals(
+            QName("urn:com:example:petstore","getPetByNameResponse"),
+            (operation.outputRef as ElementOperationMessage).elementName,
+        )
+        assertEquals(
+            QName("urn:com:example:petstore", "getPetFault"),
+            (operation.faultRef as ElementOperationMessage?)?.elementName,
+        )
     }
 
     @Test

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl2Soap12ParserTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl2Soap12ParserTest.kt
@@ -86,7 +86,7 @@ class Wsdl2Soap12ParserTest {
     }
 
     @Test
-    fun getBinding() {
+    fun `get SOAP binding, getPetById operation`() {
         val binding = parser.getBinding("SoapBinding")
         assertNotNull("SoapBinding should not be null", binding)
 
@@ -110,6 +110,46 @@ class Wsdl2Soap12ParserTest {
         assertEquals(
             QName("urn:com:example:petstore", "getPetByIdResponse"),
             (operation.outputRef as ElementOperationMessage).elementName,
+        )
+
+        // fault defined at interface level
+        assertEquals(
+            QName("urn:com:example:petstore", "getPetFault"),
+            (operation.faultRef as ElementOperationMessage?)?.elementName,
+        )
+    }
+
+    @Test
+    fun `get HTTP binding, getPetByName operation`() {
+        val binding = parser.getBinding("HttpBinding")
+        assertNotNull("HttpBinding should not be null", binding)
+
+        binding!!
+        assertEquals("HttpBinding", binding.name)
+        assertEquals(BindingType.HTTP, binding.type)
+        assertEquals("tns:PetInterface", binding.interfaceRef)
+
+        assertEquals(2, binding.operations.size)
+        val operation = binding.operations.find { it.name == "getPetByName" }
+        assertNotNull("getPetByName operation should not be null", operation)
+
+        operation!!
+        assertEquals("getPetByName", operation.name)
+        assertEquals("getPetByName", operation.soapAction)
+        assertEquals("document", operation.style)
+        assertEquals(
+            QName("urn:com:example:petstore", "getPetByNameRequest"),
+            (operation.inputRef as ElementOperationMessage).elementName,
+        )
+        assertEquals(
+            QName("urn:com:example:petstore", "getPetByNameResponse"),
+            (operation.outputRef as ElementOperationMessage).elementName,
+        )
+
+        // fault defined in operation
+        assertEquals(
+            QName("urn:com:example:petstore", "getPetFault"),
+            (operation.faultRef as ElementOperationMessage?)?.elementName,
         )
     }
 

--- a/mock/soap/src/test/resources/fault-example/imposter-config.yaml
+++ b/mock/soap/src/test/resources/fault-example/imposter-config.yaml
@@ -1,0 +1,8 @@
+plugin: soap
+wsdlFile: service.wsdl
+
+resources:
+  - binding: SoapBinding
+    operation: getPetById
+    response:
+      statusCode: 500

--- a/mock/soap/src/test/resources/fault-example/imposter-config.yaml
+++ b/mock/soap/src/test/resources/fault-example/imposter-config.yaml
@@ -6,3 +6,24 @@ resources:
     operation: getPetById
     response:
       statusCode: 500
+
+  - binding: SoapBinding
+    operation: getPetById
+    requestBody:
+      xPath: //pets:id
+      value: 99
+    response:
+      soapFault: true
+
+  - binding: SoapBinding
+    operation: getPetById
+    requestBody:
+      xPath: //pets:id
+      value: 100
+    steps:
+      - type: script
+        code: respond().withSoapFault()
+
+system:
+  xmlNamespaces:
+    pets: "urn:com:example:petstore"

--- a/mock/soap/src/test/resources/fault-example/service.wsdl
+++ b/mock/soap/src/test/resources/fault-example/service.wsdl
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<definitions name="PetService" xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:tns="urn:com:example:petstore"
+             xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+             xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+             targetNamespace="urn:com:example:petstore">
+
+    <documentation>
+        A pet store service with a single operation and SOAP binding.
+    </documentation>
+
+    <types>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                   xmlns="urn:com:example:petstore"
+                   targetNamespace="urn:com:example:petstore">
+
+            <xs:complexType name="petType">
+                <xs:all>
+                    <xs:element name="id" type="xs:int"/>
+                    <xs:element name="name" type="xs:string"/>
+                </xs:all>
+            </xs:complexType>
+
+            <xs:complexType name="getPetByIdRequest">
+                <xs:all>
+                    <xs:element name="id" type="xs:int"/>
+                </xs:all>
+            </xs:complexType>
+
+            <xs:complexType name="fault">
+                <xs:all>
+                    <xs:element name="code" type="xs:int" />
+                    <xs:element name="description" type="xs:string" />
+                </xs:all>
+            </xs:complexType>
+
+            <xs:element name="getPetByIdRequest" type="getPetByIdRequest"/>
+            <xs:element name="getPetByIdResponse" type="petType"/>
+            <xs:element name="getPetFault" type="fault"/>
+        </xs:schema>
+    </types>
+
+    <message name="getPetByIdRequest">
+        <part element="tns:getPetByIdRequest" name="parameters"/>
+    </message>
+    <message name="getPetByIdResponse">
+        <part element="tns:getPetByIdResponse" name="parameters"/>
+    </message>
+    <message name="getPetFault">
+        <part element="tns:getPetFault" name="parameters"/>
+    </message>
+
+    <portType name="PetPortType">
+        <operation name="getPetById">
+            <input message="tns:getPetByIdRequest" name="getPetByIdRequest"/>
+            <output message="tns:getPetByIdResponse" name="getPetByIdResponse"/>
+            <fault message="tns:getPetFault" name="getPetFault" />
+        </operation>
+    </portType>
+
+    <binding name="SoapBinding" type="tns:PetPortType">
+        <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/soap"/>
+
+        <operation name="getPetById">
+            <soap12:operation soapAction="getPetById" style="document"/>
+            <input name="getPetByIdRequest">
+                <soap12:body use="literal"/>
+            </input>
+            <output name="getPetByIdResponse">
+                <soap12:body use="literal"/>
+            </output>
+            <fault name="getPetFault">
+                <soap12:body use="literal"/>
+            </fault>
+        </operation>
+    </binding>
+
+    <service name="PetService">
+        <port name="SoapEndpoint" binding="tns:SoapBinding">
+            <soap12:address location="http://www.example.com/pets/"/>
+        </port>
+    </service>
+</definitions>

--- a/mock/soap/src/test/resources/wsdl1-soap11-document-bare/schema.xsd
+++ b/mock/soap/src/test/resources/wsdl1-soap11-document-bare/schema.xsd
@@ -9,6 +9,13 @@
         </xs:all>
     </xs:complexType>
 
+    <xs:complexType name="fault">
+        <xs:all>
+            <xs:element name="code" type="xs:int" />
+            <xs:element name="description" type="xs:string" />
+        </xs:all>
+    </xs:complexType>
+
     <xs:complexType name="getPetByIdRequest">
         <xs:all>
             <xs:element name="id" type="xs:int"/>
@@ -27,5 +34,5 @@
     <xs:element name="getPetByNameRequest" type="tns:getPetByNameRequest"/>
     <xs:element name="getPetByNameResponse" type="tns:petType"/>
 
-    <xs:element name="fault" type="xs:string"/>
+    <xs:element name="getPetFault" type="tns:fault"/>
 </xs:schema>

--- a/mock/soap/src/test/resources/wsdl1-soap11-document-bare/service.wsdl
+++ b/mock/soap/src/test/resources/wsdl1-soap11-document-bare/service.wsdl
@@ -105,16 +105,21 @@
     <message name="getPetByNameResponse">
         <part element="tns:getPetByNameResponse" name="parameters"/>
     </message>
+    <message name="getPetFault">
+        <part element="tns:getPetFault" name="parameters"/>
+    </message>
 
     <!-- Abstract port types -->
     <portType name="PetPortType">
         <operation name="getPetById">
             <input message="tns:getPetByIdRequest" name="getPetByIdRequest"/>
             <output message="tns:getPetByIdResponse" name="getPetByIdResponse"/>
+            <fault message="tns:getPetFault" name="getPetFault" />
         </operation>
         <operation name="getPetByName">
             <input message="tns:getPetByNameRequest" name="getPetByNameRequest"/>
             <output message="tns:getPetByNameResponse" name="getPetByNameResponse"/>
+            <fault message="tns:getPetFault" name="getPetFault" />
         </operation>
     </portType>
 
@@ -130,6 +135,9 @@
             <output name="getPetByIdResponse">
                 <soap:body use="literal"/>
             </output>
+            <fault name="getPetFault">
+                <soap:body use="literal"/>
+            </fault>
         </operation>
         <operation name="getPetByName">
             <soap:operation soapAction="getPetByName" style="document"/>
@@ -139,6 +147,9 @@
             <output name="getPetByNameResponse">
                 <soap:body use="literal"/>
             </output>
+            <fault name="getPetFault">
+                <soap:body use="literal"/>
+            </fault>
         </operation>
     </binding>
 
@@ -154,6 +165,9 @@
             <output name="getPetByIdResponse">
                 <soap:body use="literal"/>
             </output>
+            <fault name="getPetFault">
+                <soap:body use="literal"/>
+            </fault>
         </operation>
 
         <operation name="getPetByName">
@@ -165,6 +179,9 @@
             <output name="getPetByNameResponse">
                 <soap:body use="literal"/>
             </output>
+            <fault name="getPetFault">
+                <soap:body use="literal"/>
+            </fault>
         </operation>
     </binding>
 

--- a/mock/soap/src/test/resources/wsdl1-soap12/schema.xsd
+++ b/mock/soap/src/test/resources/wsdl1-soap12/schema.xsd
@@ -9,6 +9,13 @@
         </xs:all>
     </xs:complexType>
 
+    <xs:complexType name="fault">
+        <xs:all>
+            <xs:element name="code" type="xs:int" />
+            <xs:element name="description" type="xs:string" />
+        </xs:all>
+    </xs:complexType>
+
     <xs:complexType name="getPetByIdRequest">
         <xs:all>
             <xs:element name="id" type="xs:int"/>
@@ -27,5 +34,5 @@
     <xs:element name="getPetByNameRequest" type="tns:getPetByNameRequest"/>
     <xs:element name="getPetByNameResponse" type="tns:petType"/>
 
-    <xs:element name="fault" type="xs:string"/>
+    <xs:element name="getPetFault" type="tns:fault"/>
 </xs:schema>

--- a/mock/soap/src/test/resources/wsdl1-soap12/service.wsdl
+++ b/mock/soap/src/test/resources/wsdl1-soap12/service.wsdl
@@ -104,16 +104,21 @@
     <message name="getPetByNameResponse">
         <part element="tns:getPetByNameResponse" name="parameters"/>
     </message>
+    <message name="getPetFault">
+        <part element="tns:getPetFault" name="parameters"/>
+    </message>
 
     <!-- Abstract port types -->
     <portType name="PetPortType">
         <operation name="getPetById">
             <input message="tns:getPetByIdRequest" name="getPetByIdRequest"/>
             <output message="tns:getPetByIdResponse" name="getPetByIdResponse"/>
+            <fault message="tns:getPetFault" name="getPetFault" />
         </operation>
         <operation name="getPetByName">
             <input message="tns:getPetByNameRequest" name="getPetByNameRequest"/>
             <output message="tns:getPetByNameResponse" name="getPetByNameResponse"/>
+            <fault message="tns:getPetFault" name="getPetFault" />
         </operation>
     </portType>
 
@@ -129,6 +134,9 @@
             <output name="getPetByIdResponse">
                 <soap12:body use="literal"/>
             </output>
+            <fault name="getPetFault">
+                <soap12:body use="literal"/>
+            </fault>
         </operation>
         <operation name="getPetByName">
             <soap12:operation soapAction="getPetByName" style="document"/>
@@ -138,6 +146,9 @@
             <output name="getPetByNameResponse">
                 <soap12:body use="literal"/>
             </output>
+            <fault name="getPetFault">
+                <soap12:body use="literal"/>
+            </fault>
         </operation>
     </binding>
 
@@ -153,6 +164,9 @@
             <output name="getPetByIdResponse">
                 <soap12:body use="literal"/>
             </output>
+            <fault name="getPetFault">
+                <soap12:body use="literal"/>
+            </fault>
         </operation>
 
         <operation name="getPetByName">
@@ -164,6 +178,9 @@
             <output name="getPetByNameResponse">
                 <soap12:body use="literal"/>
             </output>
+            <fault name="getPetFault">
+                <soap12:body use="literal"/>
+            </fault>
         </operation>
     </binding>
 

--- a/mock/soap/src/test/resources/wsdl2-soap12/schema.xsd
+++ b/mock/soap/src/test/resources/wsdl2-soap12/schema.xsd
@@ -9,6 +9,13 @@
         </xs:all>
     </xs:complexType>
 
+    <xs:complexType name="fault">
+        <xs:all>
+            <xs:element name="code" type="xs:int" />
+            <xs:element name="description" type="xs:string" />
+        </xs:all>
+    </xs:complexType>
+
     <xs:complexType name="getPetByIdRequest">
         <xs:all>
             <xs:element name="id" type="xs:int"/>
@@ -27,5 +34,5 @@
     <xs:element name="getPetByNameRequest" type="tns:getPetByNameRequest"/>
     <xs:element name="getPetByNameResponse" type="tns:petType"/>
 
-    <xs:element name="fault" type="xs:string"/>
+    <xs:element name="getPetFault" type="tns:fault"/>
 </xs:schema>

--- a/mock/soap/src/test/resources/wsdl2-soap12/service.wsdl
+++ b/mock/soap/src/test/resources/wsdl2-soap12/service.wsdl
@@ -94,19 +94,21 @@ http://www.w3.org/ns/wsdl/soap http://www.w3.org/2002/ws/desc/ns/soap.xsd">
 
     <!-- Abstract interfaces -->
     <interface name="PetInterface">
-        <fault name="Error1" element="tns:fault"/>
+        <fault name="getPetFault" element="tns:getPetFault"/>
 
         <operation name="getPetById" pattern="http://www.w3.org/ns/wsdl/in-out">
             <wsoap:operation soapAction="getPetById" style="document"/>
             <!-- no namespace prefix for the element, so fallback to WSDL targetNamespace -->
             <input messageLabel="In" element="getPetByIdRequest"/>
             <output messageLabel="Out" element="tns:getPetByIdResponse"/>
+            <!-- no fault defined for operation, so fallback to interface -->
         </operation>
 
         <operation name="getPetByName" pattern="http://www.w3.org/ns/wsdl/in-out">
             <wsoap:operation soapAction="getPetByName" style="document"/>
             <input messageLabel="In" element="tns:getPetByNameRequest"/>
             <output messageLabel="Out" element="tns:getPetByNameResponse"/>
+            <fault name="getPetFault" element="tns:getPetFault"/>
         </operation>
     </interface>
 


### PR DESCRIPTION
fixes #618

## Returning fault messages


If your WSDL document defines a `fault`, then Imposter can generate a sample response from its type.

To return a fault you can:

1. set the response status code to `500`, or
2. set the `response.soapFault` configuration property to `true`, or
3. use the `respond().withSoapFault()` script function

### Example configuration to respond with a fault

```yaml
plugin: soap
wsdlFile: service.wsdl

resources:
  - binding: SoapBinding
    operation: getPetById
    response:
      statusCode: 500
```

> **Tip**
> Use conditional matching with resources, to only return a fault in particular circumstances. 

## Scripted example

Setting the status code to 500 will trigger a fault message to be returned if one is defined within the WSDL document.
   
```groovy
respond().withStatusCode(500)
```

or:

```groovy
respond().withSoapFault()
```