### PR TITLE
test: migrate to JUnit 5.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ ext {
     version_jackson = '2.18.0'
     version_jackson_databind = '2.18.0'
     version_jaxb_api = '2.3.1'
-    version_junit = '4.13.2'
     version_junit_jupiter = '5.10.0'
     version_log4j = '2.18.0'
     version_micrometer = '1.11.3'
@@ -90,6 +89,20 @@ subprojects {
         tasks.withType(JavaCompile) {
             sourceCompatibility = '11'
             targetCompatibility = '11'
+        }
+
+        test {
+            useJUnitPlatform {
+                if (project.hasProperty('onlyVerticleTests')) {
+                    includeTags 'verticle'
+                }
+            }
+        }
+
+        dependencies {
+            testImplementation "org.junit.jupiter:junit-jupiter-api:$version_junit_jupiter"
+            testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$version_junit_jupiter"
+            testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.10.0"
         }
 
         project.archivesBaseName = project.name.startsWith('imposter-') ? project.name : 'imposter-' + project.name

--- a/core/api/build.gradle
+++ b/core/api/build.gradle
@@ -14,7 +14,8 @@ dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     api "com.fasterxml.jackson.core:jackson-databind:$version_jackson_databind"
 
-    testImplementation "junit:junit:$version_junit"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$version_junit_jupiter"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$version_junit_jupiter"
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: version_hamcrest
 }
 
@@ -62,4 +63,8 @@ compileTestKotlin {
         // see https://kotlinlang.org/docs/java-to-kotlin-interop.html#default-methods-in-interfaces
         freeCompilerArgs = ["-Xjvm-default=all"]
     }
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/core/api/src/test/java/io/gatehill/imposter/util/MatchUtilTest.kt
+++ b/core/api/src/test/java/io/gatehill/imposter/util/MatchUtilTest.kt
@@ -45,9 +45,9 @@ package io.gatehill.imposter.util
 
 import io.gatehill.imposter.plugin.config.resource.conditional.ConditionalNameValuePair
 import io.gatehill.imposter.plugin.config.resource.conditional.MatchOperator
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [MatchUtil].

--- a/core/api/src/test/java/io/gatehill/imposter/util/ResourceUtilTest.kt
+++ b/core/api/src/test/java/io/gatehill/imposter/util/ResourceUtilTest.kt
@@ -3,9 +3,9 @@ package io.gatehill.imposter.util
 import io.gatehill.imposter.http.HttpMethod
 import io.gatehill.imposter.plugin.config.resource.ResourceConfig
 import io.gatehill.imposter.plugin.config.resource.RestResourceConfig
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [ResourceUtil].

--- a/core/config-dynamic/build.gradle
+++ b/core/config-dynamic/build.gradle
@@ -18,7 +18,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     // test
-    testImplementation "junit:junit:$version_junit"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$version_junit_jupiter"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$version_junit_jupiter"
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: version_hamcrest
     testImplementation "org.apache.logging.log4j:log4j-core:$version_log4j"
     testImplementation "org.apache.logging.log4j:log4j-slf4j18-impl:$version_log4j"
@@ -68,4 +69,8 @@ compileTestKotlin {
         // see https://kotlinlang.org/docs/java-to-kotlin-interop.html#default-methods-in-interfaces
         freeCompilerArgs = ["-Xjvm-default=all"]
     }
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/core/config-dynamic/src/test/java/io/gatehill/imposter/config/DynamicConfigUtilTest.kt
+++ b/core/config-dynamic/src/test/java/io/gatehill/imposter/config/DynamicConfigUtilTest.kt
@@ -46,10 +46,10 @@ import io.gatehill.imposter.config.util.ConfigUtil
 import io.gatehill.imposter.plugin.DynamicPluginDiscoveryStrategyImpl
 import io.gatehill.imposter.plugin.PluginManager
 import io.gatehill.imposter.plugin.PluginManagerImpl
-import org.junit.Assert
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 
 /**
@@ -60,7 +60,7 @@ import java.io.File
 class DynamicConfigUtilTest {
     private var pluginManager: PluginManager? = null
 
-    @Before
+    @BeforeEach
     fun setUp() {
         pluginManager = PluginManagerImpl(DynamicPluginDiscoveryStrategyImpl())
     }
@@ -74,7 +74,7 @@ class DynamicConfigUtilTest {
         assertEquals(1, configs.size)
 
         val pluginConfigs = configs["io.gatehill.imposter.core.test.ExamplePluginImpl"]
-        Assert.assertNotNull("Config files should be discovered", pluginConfigs)
+        Assertions.assertNotNull(pluginConfigs, "Config files should be discovered")
         assertEquals(2, pluginConfigs?.size)
     }
 }

--- a/core/config-resolver-s3/src/test/java/io/gatehill/imposter/config/S3FileDownloaderTest.kt
+++ b/core/config-resolver-s3/src/test/java/io/gatehill/imposter/config/S3FileDownloaderTest.kt
@@ -52,7 +52,8 @@ import io.gatehill.imposter.util.TestEnvironmentUtil.assumeDockerAccessible
 import io.vertx.core.AsyncResult
 import io.vertx.core.Vertx
 import org.junit.*
-import org.junit.Assert.assertTrue
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import java.io.File
 import java.nio.file.Files
 
@@ -64,7 +65,7 @@ import java.nio.file.Files
 class S3FileDownloaderTest {
     private var s3Mock: S3MockContainer? = null
 
-    @Before
+    @BeforeEach
     fun setUp() {
         // These tests need Docker
         assumeDockerAccessible()
@@ -104,17 +105,17 @@ class S3FileDownloaderTest {
         S3FileDownloader.getInstance().downloadAllFiles("s3://test", configDir)
 
         val configFile = File(configDir, "imposter-config.yaml")
-        assertTrue("config should be fetched from S3", configFile.exists() && configFile.isFile)
+        assertTrue( configFile.exists() && configFile.isFile, "config should be fetched from S3")
 
-        assertTrue("spec file should be fetched from S3", File(configDir, "pet-api.yaml").exists())
+        assertTrue( File(configDir, "pet-api.yaml").exists(), "spec file should be fetched from S3")
         assertTrue(
+            File(configDir, "subdir/response.json").exists(),
             "response file should be fetched from S3 subdir",
-            File(configDir, "subdir/response.json").exists()
         )
 
         val localSubDir = File(configDir, "unused-subdir")
-        assertTrue("local subdir should exist", localSubDir.exists())
-        assertTrue("local subdir should be a directory", localSubDir.isDirectory)
+        assertTrue( localSubDir.exists(), "local subdir should exist")
+        assertTrue( localSubDir.isDirectory, "local subdir should be a directory")
     }
 
     companion object {

--- a/core/config-resolver-s3/src/test/java/io/gatehill/imposter/config/resolver/S3ConfigResolverTest.kt
+++ b/core/config-resolver-s3/src/test/java/io/gatehill/imposter/config/resolver/S3ConfigResolverTest.kt
@@ -53,8 +53,10 @@ import io.gatehill.imposter.util.TestEnvironmentUtil.assumeDockerAccessible
 import io.vertx.core.AsyncResult
 import io.vertx.core.Vertx
 import org.junit.*
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 
 /**
  * Verifies loading remote config.
@@ -65,7 +67,7 @@ class S3ConfigResolverTest {
     private var s3Mock: S3MockContainer? = null
     private val s3ConfigResolver = S3ConfigResolver()
 
-    @Before
+    @BeforeEach
     fun setUp() {
         // These tests need Docker
         assumeDockerAccessible()
@@ -107,8 +109,8 @@ class S3ConfigResolverTest {
     @Throws(Exception::class)
     fun testLoadConfigFromS3() {
         val localConfigDir = s3ConfigResolver.resolve("s3://test")
-        Assert.assertNotNull("config should be fetched from S3", localConfigDir.exists())
-        Assert.assertEquals("files should be downloaded from S3", 3, localConfigDir.listFiles().size)
+        Assertions.assertNotNull(localConfigDir.exists(), "config should be fetched from S3")
+        Assertions.assertEquals(localConfigDir.listFiles().size, 3, "files should be downloaded from S3")
     }
 
     companion object {

--- a/core/config/build.gradle
+++ b/core/config/build.gradle
@@ -15,7 +15,8 @@ dependencies {
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$version_jackson"
 
     // test
-    testImplementation "junit:junit:$version_junit"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$version_junit_jupiter"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$version_junit_jupiter"
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: version_hamcrest
     testImplementation "org.apache.logging.log4j:log4j-core:$version_log4j"
     testImplementation "org.apache.logging.log4j:log4j-slf4j18-impl:$version_log4j"
@@ -65,4 +66,8 @@ compileTestKotlin {
         // see https://kotlinlang.org/docs/java-to-kotlin-interop.html#default-methods-in-interfaces
         freeCompilerArgs = ["-Xjvm-default=all"]
     }
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/core/config/src/main/java/io/gatehill/imposter/config/expression/SystemEvaluator.kt
+++ b/core/config/src/main/java/io/gatehill/imposter/config/expression/SystemEvaluator.kt
@@ -64,7 +64,7 @@ object SystemEvaluator : ExpressionEvaluator<String> {
             impl.eval(expression, context)
 }
 
-internal class SystemEvaluatorImpl(
+class SystemEvaluatorImpl(
     private val imposterConfig: ImposterConfig,
 ) : ExpressionEvaluator<String> {
     private val logger = LogManager.getLogger(SystemEvaluatorImpl::class.java)

--- a/core/config/src/main/java/io/gatehill/imposter/config/util/ConfigUtil.kt
+++ b/core/config/src/main/java/io/gatehill/imposter/config/util/ConfigUtil.kt
@@ -259,7 +259,7 @@ object ConfigUtil {
      * @param configRef             the configuration reference
      * @return the loaded configuration
      */
-    internal fun readPluginConfig(configRef: ConfigReference): LoadedConfig {
+    fun readPluginConfig(configRef: ConfigReference): LoadedConfig {
         val configFile = configRef.file
         try {
             val rawContents = configFile.readText()

--- a/core/config/src/test/java/io/gatehill/imposter/config/EnvVarsTest.kt
+++ b/core/config/src/test/java/io/gatehill/imposter/config/EnvVarsTest.kt
@@ -47,7 +47,7 @@ import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
 import org.hamcrest.collection.IsMapContaining
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
 /**

--- a/core/config/src/test/java/io/gatehill/imposter/config/expression/SystemEvaluatorTest.kt
+++ b/core/config/src/test/java/io/gatehill/imposter/config/expression/SystemEvaluatorTest.kt
@@ -3,8 +3,8 @@ package io.gatehill.imposter.config.expression
 import io.gatehill.imposter.ImposterConfig
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [SystemEvaluatorImpl].
@@ -12,7 +12,7 @@ import org.junit.Test
 class SystemEvaluatorTest {
     private lateinit var systemEvaluator: SystemEvaluatorImpl
 
-    @Before
+    @BeforeEach
     fun before() {
         val config = ImposterConfig().apply {
             listenPort = 8080

--- a/core/config/src/test/java/io/gatehill/imposter/util/MapUtilTest.kt
+++ b/core/config/src/test/java/io/gatehill/imposter/util/MapUtilTest.kt
@@ -2,8 +2,8 @@ package io.gatehill.imposter.util
 
 import io.vertx.core.json.JsonArray
 import io.vertx.core.json.JsonObject
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 import java.time.ZoneId
 import java.time.ZonedDateTime
 

--- a/core/engine/build.gradle
+++ b/core/engine/build.gradle
@@ -33,7 +33,8 @@ dependencies {
 
     implementation "com.squareup.okhttp3:okhttp:4.10.0"
 
-    testImplementation "junit:junit:$version_junit"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$version_junit_jupiter"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$version_junit_jupiter"
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: version_hamcrest
     testImplementation "org.mockito:mockito-core:$version_mockito"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$version_mockito_kotlin"
@@ -91,4 +92,8 @@ jar {
     manifest {
         attributes 'Imposter-Version': project.version
     }
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/core/engine/src/test/java/io/gatehill/imposter/http/AbstractResourceMatcherTest.kt
+++ b/core/engine/src/test/java/io/gatehill/imposter/http/AbstractResourceMatcherTest.kt
@@ -6,9 +6,9 @@ import io.gatehill.imposter.plugin.config.PluginConfigImpl
 import io.gatehill.imposter.util.ResourceUtil
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Assert.assertSame
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -20,7 +20,7 @@ import org.mockito.kotlin.mock
 class AbstractResourceMatcherTest {
     private lateinit var matcher: AbstractResourceMatcher
 
-    @Before
+    @BeforeEach
     fun setup() {
         matcher = object : AbstractResourceMatcher() {
             override fun matchRequest(

--- a/core/engine/src/test/java/io/gatehill/imposter/script/impl/ReadWriteResponseBehaviourImplTest.kt
+++ b/core/engine/src/test/java/io/gatehill/imposter/script/impl/ReadWriteResponseBehaviourImplTest.kt
@@ -43,8 +43,8 @@
 package io.gatehill.imposter.script.impl
 
 import io.gatehill.imposter.script.ReadWriteResponseBehaviourImpl
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
 class ReadWriteResponseBehaviourImplTest {
     @Test
@@ -52,9 +52,9 @@ class ReadWriteResponseBehaviourImplTest {
     fun shouldAddHeaderWithValue() {
         val scriptedResponseBehavior = ReadWriteResponseBehaviourImpl()
         scriptedResponseBehavior.withHeader("MyHeader", "MyValue")
-        Assert.assertEquals(1, scriptedResponseBehavior.responseHeaders.size.toLong())
-        Assert.assertTrue(scriptedResponseBehavior.responseHeaders.containsKey("MyHeader"))
-        Assert.assertEquals("MyValue", scriptedResponseBehavior.responseHeaders["MyHeader"])
+        Assertions.assertEquals(1, scriptedResponseBehavior.responseHeaders.size.toLong())
+        Assertions.assertTrue(scriptedResponseBehavior.responseHeaders.containsKey("MyHeader"))
+        Assertions.assertEquals("MyValue", scriptedResponseBehavior.responseHeaders["MyHeader"])
     }
 
     @Test
@@ -63,6 +63,6 @@ class ReadWriteResponseBehaviourImplTest {
         val scriptedResponseBehavior = ReadWriteResponseBehaviourImpl()
         scriptedResponseBehavior.responseHeaders["MyHeader"] = "MyValue"
         scriptedResponseBehavior.withHeader("MyHeader", null)
-        Assert.assertEquals(0, scriptedResponseBehavior.responseHeaders.size.toLong())
+        Assertions.assertEquals(0, scriptedResponseBehavior.responseHeaders.size.toLong())
     }
 }

--- a/core/engine/src/test/java/io/gatehill/imposter/service/CharacteristicsServiceTest.kt
+++ b/core/engine/src/test/java/io/gatehill/imposter/service/CharacteristicsServiceTest.kt
@@ -50,10 +50,15 @@ import io.gatehill.imposter.http.HttpResponse
 import io.gatehill.imposter.script.FailureSimulationType
 import io.gatehill.imposter.script.PerformanceSimulationConfig
 import io.gatehill.imposter.script.ReadWriteResponseBehaviourImpl
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
-import org.mockito.kotlin.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 
 /**
  * Tests for [CharacteristicsService].

--- a/core/engine/src/test/java/io/gatehill/imposter/service/DeferredOperationServiceTest.kt
+++ b/core/engine/src/test/java/io/gatehill/imposter/service/DeferredOperationServiceTest.kt
@@ -46,8 +46,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.apache.logging.log4j.LogManager
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [DeferredOperationService].
@@ -74,6 +74,6 @@ class DeferredOperationServiceTest {
         }.await()
         logger.trace("Execution checker stopped")
 
-        assertTrue("Operation should be executed", storedValue)
+        assertTrue(storedValue, "Operation should be executed")
     }
 }

--- a/core/engine/src/test/java/io/gatehill/imposter/service/ResponseFileServiceImplTest.kt
+++ b/core/engine/src/test/java/io/gatehill/imposter/service/ResponseFileServiceImplTest.kt
@@ -53,8 +53,8 @@ import io.gatehill.imposter.script.ReadWriteResponseBehaviourImpl
 import io.vertx.core.Vertx
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.file.FileSystem
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn

--- a/core/engine/src/test/java/io/gatehill/imposter/service/ResponseServiceImplTest.kt
+++ b/core/engine/src/test/java/io/gatehill/imposter/service/ResponseServiceImplTest.kt
@@ -43,16 +43,25 @@
 
 package io.gatehill.imposter.service
 
-import io.gatehill.imposter.http.*
+import io.gatehill.imposter.http.ExchangePhase
+import io.gatehill.imposter.http.HttpExchange
+import io.gatehill.imposter.http.HttpMethod
+import io.gatehill.imposter.http.HttpRequest
+import io.gatehill.imposter.http.HttpResponse
 import io.gatehill.imposter.plugin.config.PluginConfigImpl
 import io.gatehill.imposter.plugin.config.resource.RestResourceConfig
 import io.gatehill.imposter.script.ReadWriteResponseBehaviourImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.vertx.core.buffer.Buffer
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
-import org.mockito.kotlin.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import java.io.File
 
 /**
@@ -217,7 +226,7 @@ class ResponseServiceImplTest {
             blockExecuted = true
         }
 
-        assertTrue("the block should be executed", blockExecuted)
+        assertTrue(blockExecuted, "the block should be executed")
         verify(httpExchange).phase = ExchangePhase.RESPONSE_SENT
     }
 }

--- a/core/engine/src/test/java/io/gatehill/imposter/util/BodyQueryUtilTest.kt
+++ b/core/engine/src/test/java/io/gatehill/imposter/util/BodyQueryUtilTest.kt
@@ -51,7 +51,7 @@ import org.hamcrest.core.IsEqual
 import org.jdom2.Document
 import org.jdom2.Namespace
 import org.jdom2.input.SAXBuilder
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito.anyString
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock

--- a/core/engine/src/test/java/io/gatehill/imposter/util/HttpUtilTest.kt
+++ b/core/engine/src/test/java/io/gatehill/imposter/util/HttpUtilTest.kt
@@ -46,9 +46,9 @@ import io.gatehill.imposter.util.HttpUtil.readAcceptedContentTypes
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [HttpUtil].

--- a/core/engine/src/test/java/io/gatehill/imposter/util/PlaceholderUtilTest.kt
+++ b/core/engine/src/test/java/io/gatehill/imposter/util/PlaceholderUtilTest.kt
@@ -51,9 +51,9 @@ import io.vertx.core.buffer.Buffer
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.number.OrderingComparison
-import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -231,7 +231,7 @@ class PlaceholderUtilTest {
                 cause = cause.cause
             }
         }
-        assertEquals("IllegalStateException should be root cause", IllegalStateException::class.java, cause?.javaClass)
+        assertEquals(IllegalStateException::class.java, cause?.javaClass, "IllegalStateException should be root cause")
     }
 
     @Test

--- a/core/expression/build.gradle
+++ b/core/expression/build.gradle
@@ -12,7 +12,8 @@ dependencies {
     implementation project(':core:imposter-api')
 
     // test
-    testImplementation "junit:junit:$version_junit"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$version_junit_jupiter"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$version_junit_jupiter"
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: version_hamcrest
     testImplementation "org.apache.logging.log4j:log4j-slf4j18-impl:$version_log4j"
 }
@@ -61,4 +62,8 @@ compileTestKotlin {
         // see https://kotlinlang.org/docs/java-to-kotlin-interop.html#default-methods-in-interfaces
         freeCompilerArgs = ["-Xjvm-default=all"]
     }
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/core/expression/src/test/java/io/gatehill/imposter/expression/eval/RandomEvaluatorTest.kt
+++ b/core/expression/src/test/java/io/gatehill/imposter/expression/eval/RandomEvaluatorTest.kt
@@ -45,8 +45,8 @@ package io.gatehill.imposter.expression.eval
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.text.CharSequenceLength.hasLength
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
 class RandomEvaluatorTest {
     @Test
@@ -90,19 +90,21 @@ class RandomEvaluatorTest {
     @Test
     fun `returns null for invalid chars string`() {
         val result = RandomEvaluator.eval("""random.any(chars=notquoted, length=5)""", emptyMap<String, Any>())
-        Assert.assertNull(result)
+        Assertions.assertNull(result)
     }
 
     @Test
     fun `returns null for invalid random type`() {
         val result = RandomEvaluator.eval("random.invalid()", emptyMap<String, Any>())
-        Assert.assertNull(result)
+        Assertions.assertNull(result)
     }
 
     private fun assertContainsOnly(
         actual: String?,
         allowed: List<Char>
     ) = actual?.let {
-        if (!actual.all { allowed.contains(it) }) Assert.fail("Expected value to contain only $allowed but was: $actual")
-    } ?: Assert.fail("Expected value to contain only $allowed but was null")
+        if (!actual.all { allowed.contains(it) }) {
+            Assertions.fail<Unit>("Expected value to contain only $allowed but was: $actual")
+        }
+    } ?: Assertions.fail("Expected value to contain only $allowed but was null")
 }

--- a/core/expression/src/test/java/io/gatehill/imposter/expression/util/ExpressionUtilTest.kt
+++ b/core/expression/src/test/java/io/gatehill/imposter/expression/util/ExpressionUtilTest.kt
@@ -3,7 +3,7 @@ package io.gatehill.imposter.expression.util
 import io.gatehill.imposter.expression.eval.ExpressionEvaluator
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ExpressionUtilTest {
     @Test

--- a/docs/embed_jvm.md
+++ b/docs/embed_jvm.md
@@ -4,7 +4,7 @@ You can embed the Imposter in your JVM tests, such as JUnit or TestNG.
 
 Typically, Imposter starts before your tests, providing synthetic responses to your unit under test. You connect your component under test to the mock HTTP endpoint provided by Imposter.
 
-Imposter starts before your test runs, such as in your test set-up method (e.g. `@Before` in JUnit), providing your application with simulated HTTP responses, in place of a real endpoint.
+Imposter starts before your test runs, such as in your test set-up method (e.g. `@BeforeEach` in JUnit), providing your application with simulated HTTP responses, in place of a real endpoint.
 
 ## Getting started
 

--- a/embedded/core/src/test/java/io/gatehill/imposter/embedded/ImposterBuilderTest.java
+++ b/embedded/core/src/test/java/io/gatehill/imposter/embedded/ImposterBuilderTest.java
@@ -46,7 +46,7 @@ package io.gatehill.imposter.embedded;
 import io.gatehill.imposter.plugin.openapi.OpenApiPluginImpl;
 import io.gatehill.imposter.util.HttpUtil;
 import io.restassured.RestAssured;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/embedded/openapi/src/test/java/io/gatehill/imposter/embedded/OpenApiImposterBuilderTest.java
+++ b/embedded/openapi/src/test/java/io/gatehill/imposter/embedded/OpenApiImposterBuilderTest.java
@@ -47,7 +47,7 @@ import io.gatehill.imposter.openapi.embedded.OpenApiImposterBuilder;
 import io.gatehill.imposter.plugin.openapi.OpenApiPluginImpl;
 import io.gatehill.imposter.util.HttpUtil;
 import io.restassured.RestAssured;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/examples/junit-sample/pom.xml
+++ b/examples/junit-sample/pom.xml
@@ -95,13 +95,19 @@
       <version>2.18.2</version>
     </dependency>
 
-    <!-- testing -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
+  <!-- testing -->
+  <dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter-api</artifactId>
+    <version>5.10.0</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter-engine</artifactId>
+    <version>5.10.0</version>
+    <scope>test</scope>
+  </dependency>
 
     <!-- imposter dependencies -->
     <dependency>

--- a/examples/junit-sample/src/test/java/io/gatehill/imposter/sample/PetServiceTest.java
+++ b/examples/junit-sample/src/test/java/io/gatehill/imposter/sample/PetServiceTest.java
@@ -45,15 +45,14 @@ package io.gatehill.imposter.sample;
 
 import io.gatehill.imposter.openapi.embedded.OpenApiImposterBuilder;
 import io.gatehill.imposter.openapi.embedded.OpenApiMockEngine;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit test for pet service that calls the pet API.
@@ -61,7 +60,7 @@ import static org.junit.Assert.assertEquals;
 public class PetServiceTest {
     private PetService petService;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         Path specFile = Paths.get(PetServiceTest.class.getResource("/config/petstore-simple.yaml").toURI());
 

--- a/lib/fake-data/src/test/java/io/gatehill/imposter/plugin/fakedata/FakeEvaluatorTest.kt
+++ b/lib/fake-data/src/test/java/io/gatehill/imposter/plugin/fakedata/FakeEvaluatorTest.kt
@@ -45,7 +45,7 @@ package io.gatehill.imposter.plugin.fakedata
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.notNullValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [FakeEvaluator].

--- a/lib/fake-data/src/test/java/io/gatehill/imposter/plugin/fakedata/FakeExampleProviderTest.kt
+++ b/lib/fake-data/src/test/java/io/gatehill/imposter/plugin/fakedata/FakeExampleProviderTest.kt
@@ -47,7 +47,7 @@ import io.swagger.v3.oas.models.media.StringSchema
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.notNullValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [FakeExampleProvider].

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/ComplexPathParamsTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/ComplexPathParamsTest.kt
@@ -46,9 +46,11 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import org.junit.Before
-import org.junit.Test
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for complex path parameters.
@@ -58,10 +60,10 @@ import org.junit.Test
 class ComplexPathParamsTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 
@@ -75,7 +77,7 @@ class ComplexPathParamsTest : BaseVerticleTest() {
      * @param testContext
      */
     @Test
-    fun testServeDefaultExampleMatchContentType(testContext: TestContext) {
+    fun testServeDefaultExampleMatchContentType() {
         val body = RestAssured.given()
             .log().ifValidationFails()
             .accept(ContentType.ANY)
@@ -85,6 +87,6 @@ class ComplexPathParamsTest : BaseVerticleTest() {
             .statusCode(HttpUtil.HTTP_OK)
             .extract().asString()
 
-        testContext.assertEquals("Example artifact data", body)
+        assertEquals("Example artifact data", body)
     }
 }

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/CustomSpecPathTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/CustomSpecPathTest.kt
@@ -47,10 +47,11 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for the specification endpoint.
@@ -62,7 +63,7 @@ class CustomSpecPathTest : BaseVerticleTest() {
 
     companion object {
         @JvmStatic
-        @BeforeClass
+        @BeforeAll
         fun beforeClass() {
             EnvVars.populate(
                 "IMPOSTER_OPENAPI_SPEC_PATH_PREFIX" to "/custom-spec-path"
@@ -70,10 +71,10 @@ class CustomSpecPathTest : BaseVerticleTest() {
         }
     }
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/DefaultResponseTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/DefaultResponseTest.kt
@@ -46,9 +46,11 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import org.junit.Before
-import org.junit.Test
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for OpenAPI definitions with reference responses.
@@ -58,10 +60,10 @@ import org.junit.Test
 class DefaultResponseTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 
@@ -71,11 +73,9 @@ class DefaultResponseTest : BaseVerticleTest() {
 
     /**
      * Should return example from reference response.
-     *
-     * @param testContext
      */
     @Test
-    fun testReferenceObjectExample(testContext: TestContext) {
+    fun testReferenceObjectExample() {
         val body = RestAssured.given()
             .log().ifValidationFails()
             .accept(ContentType.JSON)
@@ -85,7 +85,7 @@ class DefaultResponseTest : BaseVerticleTest() {
             .statusCode(HttpUtil.HTTP_OK)
             .extract().jsonPath()
 
-        testContext.assertEquals(99, body.get("code"))
-        testContext.assertEquals("Default response", body.get("message"))
+        assertEquals(99, body.get("code"))
+        assertEquals("Default response", body.get("message"))
     }
 }

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/ExampleRefTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/ExampleRefTest.kt
@@ -46,10 +46,11 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for examples referenced using '$ref' in spec.
@@ -59,10 +60,10 @@ import org.junit.Test
 class ExampleRefTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/OAS2BasePathTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/OAS2BasePathTest.kt
@@ -46,11 +46,12 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
 import org.hamcrest.Matchers.notNullValue
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for operation base path for OAS2 specification.
@@ -60,10 +61,10 @@ import org.junit.Test
 class OAS2BasePathTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/OAS31Test.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/OAS31Test.kt
@@ -46,10 +46,11 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for OAS3.1 specification.
@@ -59,10 +60,10 @@ import org.junit.Test
 class OAS31Test : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/OAS3BasePathTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/OAS3BasePathTest.kt
@@ -46,15 +46,16 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasEntry
 import org.hamcrest.Matchers.hasItem
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.notNullValue
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for operation base path for OAS3 specification.
@@ -64,10 +65,10 @@ import org.junit.Test
 class OAS3BasePathTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/ObjectExamplesTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/ObjectExamplesTest.kt
@@ -46,9 +46,11 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import org.junit.Before
-import org.junit.Test
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.yaml.snakeyaml.Yaml
 
 /**
@@ -59,10 +61,10 @@ import org.yaml.snakeyaml.Yaml
 class ObjectExamplesTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 
@@ -74,7 +76,7 @@ class ObjectExamplesTest : BaseVerticleTest() {
      * Should return object example formatted as JSON.
      */
     @Test
-    fun testObjectExampleAsJson(testContext: TestContext) {
+    fun testObjectExampleAsJson() {
         val body = RestAssured.given()
             .log().ifValidationFails()
             .accept(ContentType.JSON)
@@ -84,15 +86,15 @@ class ObjectExamplesTest : BaseVerticleTest() {
             .statusCode(HttpUtil.HTTP_OK)
             .extract().jsonPath()
 
-        testContext.assertEquals(10, body.get("id"))
-        testContext.assertEquals("Engineering", body.get("name"))
+        assertEquals(10, body.get("id"))
+        assertEquals("Engineering", body.get("name"))
     }
 
     /**
      * Should return object example formatted as YAML.
      */
     @Test
-    fun testObjectExampleAsYaml(testContext: TestContext) {
+    fun testObjectExampleAsYaml() {
         val rawBody = RestAssured.given()
             .log().ifValidationFails()
             .accept("application/x-yaml")
@@ -103,8 +105,8 @@ class ObjectExamplesTest : BaseVerticleTest() {
             .extract().asString()
 
         val yamlBody = YAML_PARSER.load<Map<String, *>>(rawBody)
-        testContext.assertEquals(20, yamlBody["id"])
-        testContext.assertEquals("Product", yamlBody["name"])
+        assertEquals(20, yamlBody["id"])
+        assertEquals("Product", yamlBody["name"])
     }
 
     companion object {

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/OverrideStatusCodeTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/OverrideStatusCodeTest.kt
@@ -45,9 +45,10 @@ package io.gatehill.imposter.plugin.openapi
 import io.gatehill.imposter.server.BaseVerticleTest
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import org.junit.Before
-import org.junit.Test
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for returning specific status codes from OpenAPI mocks.
@@ -57,10 +58,10 @@ import org.junit.Test
 class OverrideStatusCodeTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/ReferenceResponseTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/ReferenceResponseTest.kt
@@ -46,9 +46,11 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import org.junit.Before
-import org.junit.Test
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for OpenAPI definitions with reference responses.
@@ -58,10 +60,10 @@ import org.junit.Test
 class ReferenceResponseTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 
@@ -71,11 +73,9 @@ class ReferenceResponseTest : BaseVerticleTest() {
 
     /**
      * Should return example from reference response.
-     *
-     * @param testContext
      */
     @Test
-    fun testReferenceObjectExample(testContext: TestContext) {
+    fun testReferenceObjectExample() {
         val body = RestAssured.given()
             .log().ifValidationFails()
             .accept(ContentType.JSON)
@@ -86,10 +86,10 @@ class ReferenceResponseTest : BaseVerticleTest() {
             .extract().jsonPath()
 
         val pets = body.getList<Any>("")
-        testContext.assertEquals(2, pets.size)
+        assertEquals(2, pets.size)
 
         val firstPet = body.getMap<Any, Any>("[0]")
-        testContext.assertEquals(101, firstPet["id"])
-        testContext.assertEquals("Cat", firstPet["name"])
+        assertEquals(101, firstPet["id"])
+        assertEquals("Cat", firstPet["name"])
     }
 }

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/RequestValidationTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/RequestValidationTest.kt
@@ -45,10 +45,11 @@ package io.gatehill.imposter.plugin.openapi
 import io.gatehill.imposter.server.BaseVerticleTest
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for request validation for OpenAPI mocks.
@@ -58,10 +59,10 @@ import org.junit.Test
 class RequestValidationTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/SchemaExamplesTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/SchemaExamplesTest.kt
@@ -46,10 +46,12 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
+import io.vertx.core.Vertx
 import io.vertx.core.json.JsonArray
-import io.vertx.ext.unit.TestContext
-import org.junit.Before
-import org.junit.Test
+import io.vertx.junit5.VertxTestContext
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.yaml.snakeyaml.Yaml
 
 /**
@@ -60,10 +62,10 @@ import org.yaml.snakeyaml.Yaml
 internal class SchemaExamplesTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 
@@ -72,7 +74,7 @@ internal class SchemaExamplesTest : BaseVerticleTest() {
     )
 
     @Test
-    fun testServeSchemaExamplesAsJson(testContext: TestContext) {
+    fun testServeSchemaExamplesAsJson() {
         val body = RestAssured.given()
             .log().ifValidationFails()
             .accept(ContentType.JSON) // JSON content type in 'Accept' header matches specification example
@@ -102,11 +104,11 @@ internal class SchemaExamplesTest : BaseVerticleTest() {
         ]
         """
         )
-        testContext.assertEquals(expected, actual)
+        assertEquals(expected, actual)
     }
 
     @Test
-    fun testServeSchemaExamplesAsYaml(testContext: TestContext) {
+    fun testServeSchemaExamplesAsYaml() {
         val rawBody = RestAssured.given()
             .log().ifValidationFails()
             .accept("application/x-yaml") // YAML content type in 'Accept' header matches specification example
@@ -117,22 +119,22 @@ internal class SchemaExamplesTest : BaseVerticleTest() {
             .extract().asString()
 
         val yamlBody = YAML_PARSER.load<List<Map<String, *>>>(rawBody)
-        testContext.assertEquals(1, yamlBody.size)
+        assertEquals(1, yamlBody.size)
 
         val first = yamlBody.first()
-        testContext.assertEquals("example", first.get("name"))
-        testContext.assertEquals(42, first.get("id"))
-        testContext.assertEquals("Collie", first.get("breed"))
-        testContext.assertEquals("test@example.com", first.get("ownerEmail"))
-        testContext.assertEquals("changeme", first.get("secret"))
-        testContext.assertEquals("2015-02-01T08:00:00Z", first.get("bornAt"))
-        testContext.assertEquals("2020-03-15", first.get("lastVetVisitOn"))
+        assertEquals("example", first.get("name"))
+        assertEquals(42, first.get("id"))
+        assertEquals("Collie", first.get("breed"))
+        assertEquals("test@example.com", first.get("ownerEmail"))
+        assertEquals("changeme", first.get("secret"))
+        assertEquals("2015-02-01T08:00:00Z", first.get("bornAt"))
+        assertEquals("2020-03-15", first.get("lastVetVisitOn"))
 
         @Suppress("UNCHECKED_CAST")
         val misc = first.get("misc") as Map<String, *>
-        testContext.assertNotNull(misc, "misc property should not be null")
-        testContext.assertEquals(false, misc.get("nocturnal"))
-        testContext.assertEquals(47435, misc.get("population"))
+        assertNotNull(misc, "misc property should not be null")
+        assertEquals(false, misc.get("nocturnal"))
+        assertEquals(47435, misc.get("population"))
     }
 
     companion object {

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/ScriptedNamedExamplesTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/ScriptedNamedExamplesTest.kt
@@ -46,10 +46,11 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for named response examples controlled by script.
@@ -59,10 +60,10 @@ import org.junit.Test
 class ScriptedNamedExamplesTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/ScriptedResponseTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/ScriptedResponseTest.kt
@@ -46,10 +46,11 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for scripted responses.
@@ -59,10 +60,10 @@ import org.junit.Test
 class ScriptedResponseTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/SecuritySchemesTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/SecuritySchemesTest.kt
@@ -46,11 +46,12 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.notNullValue
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests that security schemes are serialised correctly.
@@ -60,10 +61,10 @@ import org.junit.Test
 class SecuritySchemesTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/SlashBasePathWithHostTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/SlashBasePathWithHostTest.kt
@@ -46,9 +46,11 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import org.junit.Before
-import org.junit.Test
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for OpenAPI definitions with a single '/' as the base path and a specified host.
@@ -58,10 +60,10 @@ import org.junit.Test
 class SlashBasePathWithHostTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 
@@ -71,11 +73,9 @@ class SlashBasePathWithHostTest : BaseVerticleTest() {
 
     /**
      * Should return the example.
-     *
-     * @param testContext
      */
     @Test
-    fun testSpec(testContext: TestContext) {
+    fun testSpec() {
         val paths = RestAssured.given()
             .log().ifValidationFails()
             .accept(ContentType.JSON)
@@ -85,17 +85,15 @@ class SlashBasePathWithHostTest : BaseVerticleTest() {
             .statusCode(HttpUtil.HTTP_OK)
             .extract().jsonPath().getMap<String, Any>("paths")
 
-        testContext.assertEquals(1, paths.size)
-        testContext.assertTrue(paths.containsKey("/pets"))
+        assertEquals(1, paths.size)
+        assertTrue(paths.containsKey("/pets"))
     }
 
     /**
      * Should return the example.
-     *
-     * @param testContext
      */
     @Test
-    fun testExample(testContext: TestContext) {
+    fun testExample() {
         val body = RestAssured.given()
             .log().ifValidationFails()
             .accept(ContentType.ANY)
@@ -106,6 +104,6 @@ class SlashBasePathWithHostTest : BaseVerticleTest() {
             .extract().jsonPath()
 
         val pets = body.getList<Any>("")
-        testContext.assertEquals(2, pets.size)
+        assertEquals(2, pets.size)
     }
 }

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/StaticNamedExamplesTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/StaticNamedExamplesTest.kt
@@ -46,10 +46,11 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for named response examples controlled by config.
@@ -59,10 +60,10 @@ import org.junit.Test
 class StaticNamedExamplesTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 
@@ -83,8 +84,8 @@ class StaticNamedExamplesTest : BaseVerticleTest() {
             .then()
             .log().ifValidationFails()
             .statusCode(HttpUtil.HTTP_OK)
-            .body("id", Matchers.equalTo(1))
-            .body("name", Matchers.equalTo("Cat"))
+            .body("id", equalTo(1))
+            .body("name", equalTo("Cat"))
 
         // pet with ID 2 is Dog
         RestAssured.given()
@@ -94,7 +95,7 @@ class StaticNamedExamplesTest : BaseVerticleTest() {
             .then()
             .log().ifValidationFails()
             .statusCode(HttpUtil.HTTP_OK)
-            .body("id", Matchers.equalTo(2))
-            .body("name", Matchers.equalTo("Dog"))
+            .body("id", equalTo(2))
+            .body("name", equalTo("Dog"))
     }
 }

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/UndefinedResourceTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/UndefinedResourceTest.kt
@@ -46,10 +46,11 @@ import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for mock responses when the status code is not defined within the OpenAPI spec.
@@ -59,10 +60,10 @@ import org.junit.Test
 class UndefinedResourceTest : BaseVerticleTest() {
     override val pluginClass = OpenApiPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 
@@ -72,11 +73,9 @@ class UndefinedResourceTest : BaseVerticleTest() {
 
     /**
      * Should trigger warning and fallback handler.
-     *
-     * @param testContext
      */
     @Test
-    fun `should return fallback response`(testContext: TestContext) {
+    fun `should return fallback response`() {
         RestAssured.given()
             .log().ifValidationFails()
             .accept(ContentType.JSON)
@@ -88,11 +87,9 @@ class UndefinedResourceTest : BaseVerticleTest() {
 
     /**
      * Should return custom response.
-     *
-     * @param testContext
      */
     @Test
-    fun `should return custom response`(testContext: TestContext) {
+    fun `should return custom response`() {
         RestAssured.given()
             .log().ifValidationFails()
             .accept(ContentType.JSON)

--- a/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/service/SpecificationLoaderServiceTest.kt
+++ b/mock/openapi/src/test/java/io/gatehill/imposter/plugin/openapi/service/SpecificationLoaderServiceTest.kt
@@ -58,6 +58,7 @@ import io.vertx.core.http.HttpServer
 import io.vertx.core.http.HttpServerOptions
 import io.vertx.core.http.HttpServerRequest
 import org.junit.*
+import org.junit.jupiter.api.Assertions
 import java.net.ServerSocket
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -103,8 +104,8 @@ class SpecificationLoaderServiceTest {
         pluginConfig.specFile = specFilePath.fileName.toString()
 
         val spec = service.parseSpecification(pluginConfig)
-        Assert.assertNotNull("spec should be loaded from file", spec)
-        Assert.assertEquals("title should match", "Sample Petstore order service", spec.info.title)
+        Assertions.assertNotNull(spec, "spec should be loaded from file")
+        Assertions.assertEquals(spec.info.title, "Sample Petstore order service", "title should match")
     }
 
     /**
@@ -128,8 +129,8 @@ class SpecificationLoaderServiceTest {
         pluginConfig.specFile = "http://localhost:$listenPort"
 
         val spec = service.parseSpecification(pluginConfig)
-        Assert.assertNotNull("spec should be loaded from URL", spec)
-        Assert.assertEquals("title should match", "Sample Petstore order service", spec.info.title)
+        Assertions.assertNotNull(spec, "spec should be loaded from URL")
+        Assertions.assertEquals("Sample Petstore order service", spec.info.title, "title should match")
     }
 
     /**
@@ -157,8 +158,8 @@ class SpecificationLoaderServiceTest {
         val pluginConfig = uploadFileToS3(specFilePath)
 
         val spec = service.parseSpecification(pluginConfig)
-        Assert.assertNotNull("spec should be loaded from S3", spec)
-        Assert.assertEquals("title should match", "Sample Petstore order service", spec.info.title)
+        Assertions.assertNotNull(spec, "spec should be loaded from S3")
+        Assertions.assertEquals("Sample Petstore order service", spec.info.title, "title should match")
     }
 
     private fun uploadFileToS3(specFilePath: Path): OpenApiPluginConfig {

--- a/mock/rest/src/test/java/io/gatehill/imposter/plugin/rest/FormParamsTest.kt
+++ b/mock/rest/src/test/java/io/gatehill/imposter/plugin/rest/FormParamsTest.kt
@@ -44,13 +44,13 @@ package io.gatehill.imposter.plugin.rest
 
 import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
-import io.restassured.RestAssured
 import io.restassured.RestAssured.*
 import io.restassured.config.RedirectConfig
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests matching using form parameters.
@@ -64,13 +64,13 @@ class FormParamsTest : BaseVerticleTest() {
         "/form-params"
     )
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         baseURI = "http://$host:$listenPort"
         config().redirect(RedirectConfig.redirectConfig().followRedirects(false))
-        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
+        enableLoggingOfRequestAndResponseIfValidationFails()
     }
 
     @Test

--- a/mock/rest/src/test/java/io/gatehill/imposter/plugin/rest/PathParamsTest.kt
+++ b/mock/rest/src/test/java/io/gatehill/imposter/plugin/rest/PathParamsTest.kt
@@ -47,11 +47,12 @@ import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.RestAssured.*
 import io.restassured.config.RedirectConfig
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 
 /**
  * Tests matching using path parameters.
@@ -65,10 +66,10 @@ class PathParamsTest : BaseVerticleTest() {
         "/path-params"
     )
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         baseURI = "http://$host:$listenPort"
         config().redirect(RedirectConfig.redirectConfig().followRedirects(false))
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
@@ -174,7 +175,7 @@ class PathParamsTest : BaseVerticleTest() {
     }
 
     @Test
-    @Ignore("This isn't currently supported")
+    @Disabled("This isn't currently supported")
     fun `should match query params with NotExists operator`() {
         given()
             .`when`()

--- a/mock/rest/src/test/java/io/gatehill/imposter/plugin/rest/QueryParamsTest.kt
+++ b/mock/rest/src/test/java/io/gatehill/imposter/plugin/rest/QueryParamsTest.kt
@@ -47,10 +47,11 @@ import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.RestAssured.*
 import io.restassured.config.RedirectConfig
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests matching using query parameters.
@@ -64,10 +65,10 @@ class QueryParamsTest : BaseVerticleTest() {
         "/query-params"
     )
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         baseURI = "http://$host:$listenPort"
         config().redirect(RedirectConfig.redirectConfig().followRedirects(false))
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()

--- a/mock/rest/src/test/java/io/gatehill/imposter/plugin/rest/RequestHeaderTest.kt
+++ b/mock/rest/src/test/java/io/gatehill/imposter/plugin/rest/RequestHeaderTest.kt
@@ -47,10 +47,11 @@ import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.RestAssured.*
 import io.restassured.config.RedirectConfig
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests matching using request headers.
@@ -64,10 +65,10 @@ class RequestHeaderTest : BaseVerticleTest() {
         "/request-headers"
     )
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         baseURI = "http://$host:$listenPort"
         config().redirect(RedirectConfig.redirectConfig().followRedirects(false))
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()

--- a/mock/rest/src/test/java/io/gatehill/imposter/plugin/rest/RestPluginTest.kt
+++ b/mock/rest/src/test/java/io/gatehill/imposter/plugin/rest/RestPluginTest.kt
@@ -47,23 +47,24 @@ import io.gatehill.imposter.util.HttpUtil
 import io.gatehill.imposter.util.HttpUtil.CONTENT_TYPE
 import io.restassured.RestAssured
 import io.restassured.config.RedirectConfig
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [RestPluginImpl].
-
+ *
  * @author Pete Cornish
  */
 class RestPluginTest : BaseVerticleTest() {
     override val pluginClass = RestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.config().redirect(RedirectConfig.redirectConfig().followRedirects(false))
     }

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/AbstractEndToEndTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/AbstractEndToEndTest.kt
@@ -46,13 +46,14 @@ import io.gatehill.imposter.plugin.soap.util.SoapUtil
 import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.containsString
 import org.jdom2.Namespace
-import org.junit.Assert.assertNotNull
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Common tests for [SoapPluginImpl].
@@ -83,10 +84,10 @@ abstract class AbstractEndToEndTest : BaseVerticleTest() {
 """.trim(), soapEnvNamespace
     )
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/FaultExampleTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/FaultExampleTest.kt
@@ -46,10 +46,11 @@ import io.gatehill.imposter.plugin.soap.util.SoapUtil
 import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [SoapPluginImpl] generation of fault responses.
@@ -62,10 +63,10 @@ class FaultExampleTest : BaseVerticleTest() {
     private val soapEnvNamespace = SoapUtil.soap12RecEnvNamespace
     private val soapContentType = SoapUtil.soap12ContentType
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/JAXWSTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/JAXWSTest.kt
@@ -45,11 +45,13 @@ package io.gatehill.imposter.plugin.soap
 import com.example.petstore.ObjectFactory
 import com.example.petstore.PetService
 import io.gatehill.imposter.server.BaseVerticleTest
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import jakarta.xml.ws.BindingProvider
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [SoapPluginImpl] using JAX-WS.
@@ -62,10 +64,10 @@ class JAXWSTest : BaseVerticleTest() {
 
     private lateinit var baseURI: String
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         baseURI = "http://$host:$listenPort"
     }
 

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/NoEnvelopeTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/NoEnvelopeTest.kt
@@ -46,10 +46,11 @@ import io.gatehill.imposter.plugin.soap.util.SoapUtil
 import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests request and responses with no SOAP envelope.
@@ -61,10 +62,10 @@ class NoEnvelopeTest : BaseVerticleTest() {
     override val testConfigDirs = listOf("/no-envelope")
     private val soapContentType = SoapUtil.soap12ContentType
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/RequestBodyMatchTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/RequestBodyMatchTest.kt
@@ -46,10 +46,11 @@ import io.gatehill.imposter.plugin.soap.util.SoapUtil
 import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [SoapPluginImpl] using WSDL v1 and SOAP 1.2.
@@ -62,10 +63,10 @@ class RequestBodyMatchTest : BaseVerticleTest() {
     private val soapEnvNamespace = SoapUtil.soap12RecEnvNamespace
     private val soapContentType = SoapUtil.soap12ContentType
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/TemplateResponseTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/TemplateResponseTest.kt
@@ -46,10 +46,11 @@ import io.gatehill.imposter.plugin.soap.util.SoapUtil
 import io.gatehill.imposter.server.BaseVerticleTest
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Templates response message from request body.
@@ -62,10 +63,10 @@ class TemplateResponseTest : BaseVerticleTest() {
     private val soapEnvNamespace = SoapUtil.soap12RecEnvNamespace
     private val soapContentType = SoapUtil.soap12ContentType
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/Wsdl1Soap12EndToEndTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/Wsdl1Soap12EndToEndTest.kt
@@ -43,7 +43,7 @@
 package io.gatehill.imposter.plugin.soap
 
 import io.gatehill.imposter.plugin.soap.util.SoapUtil
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [SoapPluginImpl] using WSDL v1 and SOAP 1.2.

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/Wsdl2Soap12EndToEndTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/Wsdl2Soap12EndToEndTest.kt
@@ -43,7 +43,7 @@
 package io.gatehill.imposter.plugin.soap
 
 import io.gatehill.imposter.plugin.soap.util.SoapUtil
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [SoapPluginImpl] using WSDL v2 and SOAP 1.2.

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/AbstractWsdlParserTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/AbstractWsdlParserTest.kt
@@ -51,7 +51,7 @@ import org.hamcrest.Matchers.notNullValue
 import org.jdom2.Document
 import org.jdom2.Element
 import org.jdom2.Namespace
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.xml.sax.EntityResolver
 import java.io.File

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/VersionAwareWsdlParserTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/VersionAwareWsdlParserTest.kt
@@ -43,8 +43,8 @@
 
 package io.gatehill.imposter.plugin.soap.parser
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 import java.io.File
 
 /**

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Soap11ParserTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Soap11ParserTest.kt
@@ -46,10 +46,10 @@ package io.gatehill.imposter.plugin.soap.parser
 import io.gatehill.imposter.plugin.soap.model.BindingType
 import io.gatehill.imposter.plugin.soap.model.ElementOperationMessage
 import org.jdom2.input.SAXBuilder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 import javax.xml.namespace.QName
 
@@ -61,7 +61,7 @@ import javax.xml.namespace.QName
 class Wsdl1Soap11ParserTest {
     private lateinit var parser: Wsdl1Parser
 
-    @Before
+    @BeforeEach
     fun setUp() {
         val wsdlFile = File(Wsdl1Soap11ParserTest::class.java.getResource("/wsdl1-soap11-document-bare/service.wsdl")!!.toURI())
         val document = SAXBuilder().build(wsdlFile)
@@ -74,7 +74,7 @@ class Wsdl1Soap11ParserTest {
         assertEquals(1, parser.services.size)
 
         val petService = parser.services.find { it.name == "PetService" }
-        assertNotNull("PetService should not be null", petService)
+        assertNotNull(petService, "PetService should not be null")
 
         petService!!
         assertEquals("PetService", petService.name)
@@ -88,7 +88,7 @@ class Wsdl1Soap11ParserTest {
     @Test
     fun `get SOAP binding, getPetById operation`() {
         val binding = parser.getBinding("SoapBinding")
-        assertNotNull("SoapBinding should not be null", binding)
+        assertNotNull(binding, "SoapBinding should not be null")
 
         binding!!
         assertEquals("SoapBinding", binding.name)
@@ -97,7 +97,7 @@ class Wsdl1Soap11ParserTest {
 
         assertEquals(2, binding.operations.size)
         val operation = binding.operations.find { it.name == "getPetById" }
-        assertNotNull("getPetById operation should not be null", operation)
+        assertNotNull(operation, "getPetById operation should not be null")
 
         operation!!
         assertEquals("getPetById", operation.name)
@@ -123,7 +123,7 @@ class Wsdl1Soap11ParserTest {
     @Test
     fun `get HTTP binding, getPetByName operation`() {
         val binding = parser.getBinding("HttpBinding")
-        assertNotNull("HttpBinding should not be null", binding)
+        assertNotNull(binding, "HttpBinding should not be null")
 
         binding!!
         assertEquals("HttpBinding", binding.name)
@@ -132,7 +132,7 @@ class Wsdl1Soap11ParserTest {
 
         assertEquals(2, binding.operations.size)
         val operation = binding.operations.find { it.name == "getPetByName" }
-        assertNotNull("getPetByName operation should not be null", operation)
+        assertNotNull(operation, "getPetByName operation should not be null")
 
         operation!!
         assertEquals("getPetByName", operation.name)
@@ -158,7 +158,7 @@ class Wsdl1Soap11ParserTest {
     @Test
     fun getInterface() {
         val iface = parser.getInterface("PetPortType")
-        assertNotNull("PetPortType should not be null", iface)
+        assertNotNull(iface, "PetPortType should not be null")
 
         iface!!
         assertEquals("PetPortType", iface.name)

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Soap12ParserTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl1Soap12ParserTest.kt
@@ -46,10 +46,10 @@ package io.gatehill.imposter.plugin.soap.parser
 import io.gatehill.imposter.plugin.soap.model.BindingType
 import io.gatehill.imposter.plugin.soap.model.ElementOperationMessage
 import org.jdom2.input.SAXBuilder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 import javax.xml.namespace.QName
 
@@ -61,7 +61,7 @@ import javax.xml.namespace.QName
 class Wsdl1Soap12ParserTest {
     private lateinit var parser: Wsdl1Parser
 
-    @Before
+    @BeforeEach
     fun setUp() {
         val wsdlFile = File(Wsdl1Soap12ParserTest::class.java.getResource("/wsdl1-soap12/service.wsdl")!!.toURI())
         val document = SAXBuilder().build(wsdlFile)
@@ -74,7 +74,7 @@ class Wsdl1Soap12ParserTest {
         assertEquals(1, parser.services.size)
 
         val petService = parser.services.find { it.name == "PetService" }
-        assertNotNull("PetService should not be null", petService)
+        assertNotNull(petService, "PetService should not be null")
 
         petService!!
         assertEquals("PetService", petService.name)
@@ -88,7 +88,7 @@ class Wsdl1Soap12ParserTest {
     @Test
     fun `get SOAP binding, getPetById operation`() {
         val binding = parser.getBinding("SoapBinding")
-        assertNotNull("SoapBinding should not be null", binding)
+        assertNotNull(binding, "SoapBinding should not be null")
 
         binding!!
         assertEquals("SoapBinding", binding.name)
@@ -97,7 +97,7 @@ class Wsdl1Soap12ParserTest {
 
         assertEquals(2, binding.operations.size)
         val operation = binding.operations.find { it.name == "getPetById" }
-        assertNotNull("getPetById operation should not be null", operation)
+        assertNotNull(operation, "getPetById operation should not be null")
 
         operation!!
         assertEquals("getPetById", operation.name)
@@ -123,7 +123,7 @@ class Wsdl1Soap12ParserTest {
     @Test
     fun `get HTTP binding, getPetByName operation`() {
         val binding = parser.getBinding("HttpBinding")
-        assertNotNull("HttpBinding should not be null", binding)
+        assertNotNull(binding, "HttpBinding should not be null")
 
         binding!!
         assertEquals("HttpBinding", binding.name)
@@ -132,7 +132,7 @@ class Wsdl1Soap12ParserTest {
 
         assertEquals(2, binding.operations.size)
         val operation = binding.operations.find { it.name == "getPetByName" }
-        assertNotNull("getPetByName operation should not be null", operation)
+        assertNotNull(operation, "getPetByName operation should not be null")
 
         operation!!
         assertEquals("getPetByName", operation.name)
@@ -158,7 +158,7 @@ class Wsdl1Soap12ParserTest {
     @Test
     fun getInterface() {
         val iface = parser.getInterface("PetPortType")
-        assertNotNull("PetPortType should not be null", iface)
+        assertNotNull(iface, "PetPortType should not be null")
 
         iface!!
         assertEquals("PetPortType", iface.name)

--- a/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl2Soap12ParserTest.kt
+++ b/mock/soap/src/test/java/io/gatehill/imposter/plugin/soap/parser/Wsdl2Soap12ParserTest.kt
@@ -46,10 +46,10 @@ package io.gatehill.imposter.plugin.soap.parser
 import io.gatehill.imposter.plugin.soap.model.BindingType
 import io.gatehill.imposter.plugin.soap.model.ElementOperationMessage
 import org.jdom2.input.SAXBuilder
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 import javax.xml.namespace.QName
 
@@ -61,7 +61,7 @@ import javax.xml.namespace.QName
 class Wsdl2Soap12ParserTest {
     private lateinit var parser: Wsdl2Parser
 
-    @Before
+    @BeforeEach
     fun setUp() {
         val wsdlFile = File(Wsdl2Soap12ParserTest::class.java.getResource("/wsdl2-soap12/service.wsdl")!!.toURI())
         val document = SAXBuilder().build(wsdlFile)
@@ -74,7 +74,7 @@ class Wsdl2Soap12ParserTest {
         assertEquals(1, parser.services.size)
 
         val petService = parser.services.find { it.name == "PetService" }
-        assertNotNull("PetService should not be null", petService)
+        assertNotNull(petService, "PetService should not be null")
 
         petService!!
         assertEquals("PetService", petService.name)
@@ -88,7 +88,7 @@ class Wsdl2Soap12ParserTest {
     @Test
     fun `get SOAP binding, getPetById operation`() {
         val binding = parser.getBinding("SoapBinding")
-        assertNotNull("SoapBinding should not be null", binding)
+        assertNotNull(binding, "SoapBinding should not be null")
 
         binding!!
         assertEquals("SoapBinding", binding.name)
@@ -97,7 +97,7 @@ class Wsdl2Soap12ParserTest {
 
         assertEquals(2, binding.operations.size)
         val operation = binding.operations.find { it.name == "getPetById" }
-        assertNotNull("getPetById operation should not be null", operation)
+        assertNotNull(operation, "getPetById operation should not be null")
 
         operation!!
         assertEquals("getPetById", operation.name)
@@ -122,7 +122,7 @@ class Wsdl2Soap12ParserTest {
     @Test
     fun `get HTTP binding, getPetByName operation`() {
         val binding = parser.getBinding("HttpBinding")
-        assertNotNull("HttpBinding should not be null", binding)
+        assertNotNull(binding, "HttpBinding should not be null")
 
         binding!!
         assertEquals("HttpBinding", binding.name)
@@ -131,7 +131,7 @@ class Wsdl2Soap12ParserTest {
 
         assertEquals(2, binding.operations.size)
         val operation = binding.operations.find { it.name == "getPetByName" }
-        assertNotNull("getPetByName operation should not be null", operation)
+        assertNotNull(operation, "getPetByName operation should not be null")
 
         operation!!
         assertEquals("getPetByName", operation.name)
@@ -156,7 +156,7 @@ class Wsdl2Soap12ParserTest {
     @Test
     fun getInterface() {
         val iface = parser.getInterface("PetInterface")
-        assertNotNull("PetInterface should not be null", iface)
+        assertNotNull(iface, "PetInterface should not be null")
 
         iface!!
         assertEquals("PetInterface", iface.name)

--- a/mock/wiremock/src/test/java/io/gatehill/imposter/plugin/wiremock/WiremockPluginTest.kt
+++ b/mock/wiremock/src/test/java/io/gatehill/imposter/plugin/wiremock/WiremockPluginTest.kt
@@ -57,8 +57,9 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.hasSize
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import java.io.File
 
@@ -73,7 +74,7 @@ class WiremockPluginTest {
         val configDir = convert("/wiremock-nowrap")
 
         val files = configDir.listFiles()?.map { it.name }
-        Assert.assertEquals(2, files?.size)
+        Assertions.assertEquals(2, files?.size)
 
         assertThat(files, CoreMatchers.hasItem("wiremock-0-config.json"))
         assertThat(files, CoreMatchers.hasItem("files"))
@@ -84,14 +85,14 @@ class WiremockPluginTest {
         val configDir = convert("/wiremock-simple")
 
         val files = configDir.listFiles()?.map { it.name }
-        Assert.assertEquals(2, files?.size)
+        Assertions.assertEquals(2, files?.size)
 
         assertThat(files, CoreMatchers.hasItem("wiremock-0-config.json"))
         assertThat(files, CoreMatchers.hasItem("files"))
 
         val responseFileDir = File(configDir, "files")
         val responseFiles = responseFileDir.listFiles()?.map { it.name }
-        Assert.assertEquals(1, responseFiles?.size)
+        Assertions.assertEquals(1, responseFiles?.size)
         assertThat(responseFiles, CoreMatchers.hasItem("response.json"))
     }
 
@@ -100,7 +101,7 @@ class WiremockPluginTest {
         val configDir = convert("/wiremock-simple", 2, "IMPOSTER_WIREMOCK_SEPARATE_CONFIG" to "true")
 
         val files = configDir.listFiles()?.map { it.name }
-        Assert.assertEquals(3, files?.size)
+        Assertions.assertEquals(3, files?.size)
 
         assertThat(files, CoreMatchers.hasItem("wiremock-0-config.json"))
         assertThat(files, CoreMatchers.hasItem("wiremock-1-config.json"))
@@ -108,7 +109,7 @@ class WiremockPluginTest {
 
         val responseFileDir = File(configDir, "files")
         val responseFiles = responseFileDir.listFiles()?.map { it.name }
-        Assert.assertEquals(1, responseFiles?.size)
+        Assertions.assertEquals(1, responseFiles?.size)
         assertThat(responseFiles, CoreMatchers.hasItem("response.json"))
     }
 
@@ -117,14 +118,14 @@ class WiremockPluginTest {
         val configDir = convert("/wiremock-templated")
 
         val files = configDir.listFiles()?.map { it.name }
-        Assert.assertEquals(2, files?.size)
+        Assertions.assertEquals(2, files?.size)
 
         assertThat(files, CoreMatchers.hasItem("wiremock-0-config.json"))
         assertThat(files, CoreMatchers.hasItem("files"))
 
         val responseFileDir = File(configDir, "files")
         val responseFiles = responseFileDir.listFiles()?.map { it.name }
-        Assert.assertEquals(1, responseFiles?.size)
+        Assertions.assertEquals(1, responseFiles?.size)
         assertThat(responseFiles, CoreMatchers.hasItem("response.xml"))
 
         val responseFile = File(responseFileDir, "response.xml").readText()
@@ -165,7 +166,7 @@ class WiremockPluginTest {
 
         val configDir = loadedConfigs.first().ref.file.parentFile
 
-        Assert.assertTrue("Config dir should exist", configDir.exists())
+        assertTrue(configDir.exists(), "Config dir should exist")
         assertThat(
             "Config dir should differ from source dir",
             configDir,

--- a/scripting/graalvm/src/test/java/io/gatehill/imposter/service/AdditionalContextPropertiesTest.kt
+++ b/scripting/graalvm/src/test/java/io/gatehill/imposter/service/AdditionalContextPropertiesTest.kt
@@ -47,7 +47,7 @@ import io.gatehill.imposter.scripting.AbstractBaseScriptTest
 import io.gatehill.imposter.scripting.graalvm.service.GraalvmScriptServiceImpl
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 /**

--- a/scripting/graalvm/src/test/java/io/gatehill/imposter/service/RequireTypesTest.kt
+++ b/scripting/graalvm/src/test/java/io/gatehill/imposter/service/RequireTypesTest.kt
@@ -45,8 +45,10 @@ package io.gatehill.imposter.service
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.scripting.AbstractBaseScriptTest
 import io.gatehill.imposter.scripting.graalvm.service.GraalvmScriptServiceImpl
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 /**
@@ -72,9 +74,9 @@ class RequireTypesTest : AbstractBaseScriptTest() {
         val script = resolveScriptFile(pluginConfig, resourceConfig)
         val actual = getService().executeScript(script, scriptBindings)
 
-        Assert.assertNotNull(actual)
-        Assert.assertEquals(201, actual.statusCode)
-        Assert.assertEquals("foo", actual.content)
-        Assert.assertNull("Behaviour type should not be set", actual.behaviourType)
+        assertNotNull(actual)
+        assertEquals(201, actual.statusCode)
+        assertEquals("foo", actual.content)
+        assertNull(actual.behaviourType, "Behaviour type should not be set")
     }
 }

--- a/scripting/graalvm/src/test/java/io/gatehill/imposter/service/StoreJsonTest.kt
+++ b/scripting/graalvm/src/test/java/io/gatehill/imposter/service/StoreJsonTest.kt
@@ -56,7 +56,7 @@ import io.gatehill.imposter.store.service.StoreServiceImpl
 import io.gatehill.imposter.util.asSingleton
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 /**

--- a/scripting/groovy/src/test/java/io/gatehill/imposter/service/GroovyScriptClosureTest.kt
+++ b/scripting/groovy/src/test/java/io/gatehill/imposter/service/GroovyScriptClosureTest.kt
@@ -45,8 +45,8 @@ package io.gatehill.imposter.service
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.scripting.AbstractBaseScriptTest
 import io.gatehill.imposter.scripting.groovy.service.GroovyScriptServiceImpl
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 /**
@@ -69,8 +69,8 @@ class GroovyScriptClosureTest : AbstractBaseScriptTest() {
         val script = resolveScriptFile(pluginConfig, resourceConfig)
         val actual = getService().executeScript(script, scriptBindings)
 
-        Assert.assertNotNull(actual)
-        Assert.assertEquals("closure", actual.content)
-        Assert.assertEquals(201, actual.statusCode)
+        Assertions.assertNotNull(actual)
+        Assertions.assertEquals("closure", actual.content)
+        Assertions.assertEquals(201, actual.statusCode)
     }
 }

--- a/scripting/groovy/src/test/java/io/gatehill/imposter/service/GroovyScriptIncludeFileTest.kt
+++ b/scripting/groovy/src/test/java/io/gatehill/imposter/service/GroovyScriptIncludeFileTest.kt
@@ -45,8 +45,8 @@ package io.gatehill.imposter.service
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.scripting.AbstractBaseScriptTest
 import io.gatehill.imposter.scripting.groovy.service.GroovyScriptServiceImpl
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 /**
@@ -69,7 +69,7 @@ class GroovyScriptIncludeFileTest : AbstractBaseScriptTest() {
         val script = resolveScriptFile(pluginConfig, resourceConfig)
         val actual = getService().executeScript(script, scriptBindings)
 
-        Assert.assertNotNull(actual)
-        Assert.assertEquals(201, actual.statusCode)
+        Assertions.assertNotNull(actual)
+        Assertions.assertEquals(201, actual.statusCode)
     }
 }

--- a/scripting/groovy/src/test/java/io/gatehill/imposter/service/GroovyScriptJsonTest.kt
+++ b/scripting/groovy/src/test/java/io/gatehill/imposter/service/GroovyScriptJsonTest.kt
@@ -45,8 +45,8 @@ package io.gatehill.imposter.service
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.scripting.AbstractBaseScriptTest
 import io.gatehill.imposter.scripting.groovy.service.GroovyScriptServiceImpl
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 /**
@@ -69,7 +69,7 @@ class GroovyScriptJsonTest : AbstractBaseScriptTest() {
         val script = resolveScriptFile(pluginConfig, resourceConfig)
         val actual = getService().executeScript(script, scriptBindings)
 
-        Assert.assertNotNull(actual)
-        Assert.assertEquals("world", actual.content)
+        Assertions.assertNotNull(actual)
+        Assertions.assertEquals("world", actual.content)
     }
 }

--- a/scripting/nashorn/src/test/java/io/gatehill/imposter/service/RequireTypesTest.kt
+++ b/scripting/nashorn/src/test/java/io/gatehill/imposter/service/RequireTypesTest.kt
@@ -45,8 +45,10 @@ package io.gatehill.imposter.service
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.scripting.AbstractBaseScriptTest
 import io.gatehill.imposter.scripting.nashorn.service.NashornScriptServiceImpl
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
 /**
@@ -72,9 +74,9 @@ class RequireTypesTest : AbstractBaseScriptTest() {
         val script = resolveScriptFile(pluginConfig, resourceConfig)
         val actual = getService().executeScript(script, scriptBindings)
 
-        Assert.assertNotNull(actual)
-        Assert.assertEquals(201, actual.statusCode)
-        Assert.assertEquals("foo", actual.content)
-        Assert.assertNull("Behaviour type should not be set", actual.behaviourType)
+        assertNotNull(actual)
+        assertEquals(201, actual.statusCode)
+        assertEquals("foo", actual.content)
+        assertNull(actual.behaviourType, "Behaviour type should not be set")
     }
 }

--- a/server/src/test/java/io/gatehill/imposter/server/CaptureTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/CaptureTest.kt
@@ -47,13 +47,12 @@ import io.gatehill.imposter.util.HttpUtil
 import io.gatehill.imposter.util.attempt
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 
 /**
@@ -61,14 +60,13 @@ import java.io.File
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class CaptureTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/CorsTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/CorsTest.kt
@@ -45,26 +45,24 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.*
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for CORS.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class CorsTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/DeprecatedResponseConfigTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/DeprecatedResponseConfigTest.kt
@@ -45,26 +45,24 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
-import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for legacy response configuration.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class DeprecatedResponseConfigTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }
@@ -78,8 +76,8 @@ class DeprecatedResponseConfigTest : BaseVerticleTest() {
         RestAssured.given().`when`()
             .get("/legacy-content")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_OK))
-            .body(Matchers.equalTo("Hello content"))
+            .statusCode(equalTo(HttpUtil.HTTP_OK))
+            .body(equalTo("Hello content"))
     }
 
     @Test
@@ -87,8 +85,8 @@ class DeprecatedResponseConfigTest : BaseVerticleTest() {
         RestAssured.given().`when`()
             .get("/legacy-file")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_OK))
-            .body(Matchers.equalTo("Hello file"))
+            .statusCode(equalTo(HttpUtil.HTTP_OK))
+            .body(equalTo("Hello file"))
     }
 
     @Test
@@ -96,7 +94,7 @@ class DeprecatedResponseConfigTest : BaseVerticleTest() {
         RestAssured.given().`when`()
             .get("/legacy-script")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_OK))
-            .body(Matchers.equalTo("Hello script"))
+            .statusCode(equalTo(HttpUtil.HTTP_OK))
+            .body(equalTo("Hello script"))
     }
 }

--- a/server/src/test/java/io/gatehill/imposter/server/ExpressionMatcherTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/ExpressionMatcherTest.kt
@@ -44,26 +44,23 @@ package io.gatehill.imposter.server
 
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for expression matcher functionality.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class ExpressionMatcherTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
-    @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    @BeforeEach
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/FailureSimulationTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/FailureSimulationTest.kt
@@ -45,27 +45,26 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.apache.http.NoHttpResponseException
 import org.hamcrest.Matchers.*
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 /**
  * Tests for failure simulation.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class FailureSimulationTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 
@@ -83,13 +82,15 @@ class FailureSimulationTest : BaseVerticleTest() {
             .headers(emptyMap<String, String>())
     }
 
-    @Test(expected = NoHttpResponseException::class)
+    @Test
     fun `test close connection failure`() {
-        RestAssured.given().`when`()
-            .get("/static-failure-close")
-            .then()
-            .statusCode(equalTo(0))
-            .body(hasLength(0))
-            .headers(emptyMap<String, String>())
+        assertThrows<NoHttpResponseException> {
+            RestAssured.given().`when`()
+                .get("/static-failure-close")
+                .then()
+                .statusCode(equalTo(0))
+                .body(hasLength(0))
+                .headers(emptyMap<String, String>())
+        }
     }
 }

--- a/server/src/test/java/io/gatehill/imposter/server/ImposterVerticleTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/ImposterVerticleTest.kt
@@ -52,24 +52,23 @@ import io.gatehill.imposter.util.FileUtil.CLASSPATH_PREFIX
 import io.gatehill.imposter.util.HttpUtil
 import io.gatehill.imposter.util.InjectorUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class ImposterVerticleTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
 
         // set up trust store for TLS
         RestAssured.trustStore(getDefaultKeystore(ImposterVerticleTest::class.java).toFile(), DEFAULT_KEYSTORE_PASSWORD)
@@ -91,17 +90,17 @@ class ImposterVerticleTest : BaseVerticleTest() {
     }
 
     @Test
-    fun testPluginLoadAndConfig(testContext: TestContext) {
+    fun testPluginLoadAndConfig() {
         val pluginManager = InjectorUtil.getInstance<PluginManager>()
         val plugin = pluginManager.getPlugin<TestPluginImpl>(TestPluginImpl::class.java.canonicalName)
-        testContext.assertNotNull(plugin)
-        testContext.assertNotNull(plugin!!.configs)
-        testContext.assertEquals(1, plugin.configs.size)
+        Assertions.assertNotNull(plugin)
+        Assertions.assertNotNull(plugin!!.configs)
+        Assertions.assertEquals(1, plugin.configs.size)
 
         val pluginConfig = plugin.configs[0]
-        testContext.assertEquals("/example", pluginConfig.path)
-        testContext.assertEquals("test-plugin-data.json", pluginConfig.responseConfig.file)
-        testContext.assertEquals("testValue", pluginConfig.customProperty)
+        Assertions.assertEquals("/example", pluginConfig.path)
+        Assertions.assertEquals("test-plugin-data.json", pluginConfig.responseConfig.file)
+        Assertions.assertEquals("testValue", pluginConfig.customProperty)
     }
 
     @Test

--- a/server/src/test/java/io/gatehill/imposter/server/InheritRootResponseConfigTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/InheritRootResponseConfigTest.kt
@@ -45,26 +45,24 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
-import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for inheriting the root response configuration.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class InheritRootResponseConfigTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }
@@ -81,8 +79,8 @@ class InheritRootResponseConfigTest : BaseVerticleTest() {
         RestAssured.given().`when`()
             .get("/example")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_OK))
-            .body(Matchers.equalTo("Hello world")) // header inherited from root response config
+            .statusCode(equalTo(HttpUtil.HTTP_OK))
+            .body(equalTo("Hello world")) // header inherited from root response config
             .header("X-Always-Present", "Yes")
     }
 
@@ -95,6 +93,6 @@ class InheritRootResponseConfigTest : BaseVerticleTest() {
         RestAssured.given().`when`()
             .get("/")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_NOT_FOUND))
+            .statusCode(equalTo(HttpUtil.HTTP_NOT_FOUND))
     }
 }

--- a/server/src/test/java/io/gatehill/imposter/server/InlineScriptEvalTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/InlineScriptEvalTest.kt
@@ -44,26 +44,24 @@ package io.gatehill.imposter.server
 
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for matching requests using inline script evaluation.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class InlineScriptEvalTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/InterceptorTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/InterceptorTest.kt
@@ -44,26 +44,23 @@ package io.gatehill.imposter.server
 
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
- * Tests for kebab-case path parameters.
+ * Tests for interceptor functionality.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class InterceptorTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
-    @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    @BeforeEach
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/KebabCaseParamsTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/KebabCaseParamsTest.kt
@@ -44,26 +44,24 @@ package io.gatehill.imposter.server
 
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for kebab-case path parameters.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class KebabCaseParamsTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/PerformanceSimulationTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/PerformanceSimulationTest.kt
@@ -45,27 +45,24 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for performance simulation.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class PerformanceSimulationTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
-    @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    @BeforeEach
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 
@@ -84,9 +81,9 @@ class PerformanceSimulationTest : BaseVerticleTest() {
             .then()
             .statusCode(Matchers.equalTo(HttpUtil.HTTP_OK))
         val latency = System.currentTimeMillis() - startMs
-        Assert.assertTrue(
-            "Response latency should be >= 500ms - was: $latency",
-            latency >= 500
+        Assertions.assertTrue(
+            latency >= 500,
+            "Response latency should be >= 500ms - was: $latency"
         )
     }
 
@@ -102,9 +99,9 @@ class PerformanceSimulationTest : BaseVerticleTest() {
             .then()
             .statusCode(Matchers.equalTo(HttpUtil.HTTP_OK))
         val latency = System.currentTimeMillis() - startMs
-        Assert.assertTrue(
-            "Response latency should be >= 200ms and <= 400ms - was: $latency",
-            latency >= 200 && latency <= 400 + MEASUREMENT_TOLERANCE
+        Assertions.assertTrue(
+            latency >= 200 && latency <= 400 + MEASUREMENT_TOLERANCE,
+            "Response latency should be >= 200ms and <= 400ms - was: $latency"
         )
     }
 
@@ -119,9 +116,9 @@ class PerformanceSimulationTest : BaseVerticleTest() {
             .then()
             .statusCode(Matchers.equalTo(HttpUtil.HTTP_OK))
         val latency = System.currentTimeMillis() - startMs
-        Assert.assertTrue(
-            "Response latency should be >= 500ms - was: $latency",
-            latency >= 500
+        Assertions.assertTrue(
+            latency >= 500,
+            "Response latency should be >= 500ms - was: $latency"
         )
     }
 
@@ -137,9 +134,9 @@ class PerformanceSimulationTest : BaseVerticleTest() {
             .then()
             .statusCode(Matchers.equalTo(HttpUtil.HTTP_OK))
         val latency = System.currentTimeMillis() - startMs
-        Assert.assertTrue(
-            "Response latency should be >= 200ms and <= 400ms - was: $latency",
-            latency >= 200 && latency <= 400 + MEASUREMENT_TOLERANCE
+        Assertions.assertTrue(
+            latency >= 200 && latency <= 400 + MEASUREMENT_TOLERANCE,
+            "Response latency should be >= 200ms and <= 400ms - was: $latency"
         )
     }
 

--- a/server/src/test/java/io/gatehill/imposter/server/PreferExactPathTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/PreferExactPathTest.kt
@@ -44,26 +44,24 @@ package io.gatehill.imposter.server
 
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for preferring paths with exact matches over those with placeholders.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class PreferExactPathTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/RequestBodyJsonPathTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/RequestBodyJsonPathTest.kt
@@ -45,27 +45,24 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.hasLength
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for matching request body with JsonPath.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class RequestBodyJsonPathTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/RequestBodyStringTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/RequestBodyStringTest.kt
@@ -45,27 +45,24 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.hasLength
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for matching request body with JsonPath.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class RequestBodyStringTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/RequestBodyXPathTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/RequestBodyXPathTest.kt
@@ -45,27 +45,24 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
-import org.hamcrest.Matchers
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.hamcrest.Matchers.hasLength
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for matching request body with XPath.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class RequestBodyXPathTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
-    @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    @BeforeEach
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }
@@ -359,7 +356,7 @@ class RequestBodyXPathTest : BaseVerticleTest() {
 """.trim())
             .post("/example-allof")
             .then()
-            .body(Matchers.hasLength(0))
+            .body(hasLength(0))
     }
 
     /**

--- a/server/src/test/java/io/gatehill/imposter/server/RequestMatchingTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/RequestMatchingTest.kt
@@ -45,26 +45,24 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
-import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for matching path parameters.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class RequestMatchingTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }
@@ -81,7 +79,7 @@ class RequestMatchingTest : BaseVerticleTest() {
         RestAssured.given().`when`()
             .get("/users/1")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_NO_CONTENT))
+            .statusCode(equalTo(HttpUtil.HTTP_NO_CONTENT))
     }
 
     /**
@@ -92,7 +90,7 @@ class RequestMatchingTest : BaseVerticleTest() {
         RestAssured.given().`when`()
             .get("/orders/99")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_NOT_AUTHORITATIVE))
+            .statusCode(equalTo(HttpUtil.HTTP_NOT_AUTHORITATIVE))
     }
 
     /**
@@ -103,31 +101,31 @@ class RequestMatchingTest : BaseVerticleTest() {
         RestAssured.given().`when`()
             .get("/example")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_ACCEPTED))
+            .statusCode(equalTo(HttpUtil.HTTP_ACCEPTED))
 
         RestAssured.given().`when`()
             .post("/example")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_ACCEPTED))
+            .statusCode(equalTo(HttpUtil.HTTP_ACCEPTED))
 
         RestAssured.given().`when`()
             .put("/example")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_ACCEPTED))
+            .statusCode(equalTo(HttpUtil.HTTP_ACCEPTED))
 
         RestAssured.given().`when`()
             .patch("/example")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_ACCEPTED))
+            .statusCode(equalTo(HttpUtil.HTTP_ACCEPTED))
 
         RestAssured.given().`when`()
             .delete("/example")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_ACCEPTED))
+            .statusCode(equalTo(HttpUtil.HTTP_ACCEPTED))
 
         RestAssured.given().`when`()
             .head("/example")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_ACCEPTED))
+            .statusCode(equalTo(HttpUtil.HTTP_ACCEPTED))
     }
 }

--- a/server/src/test/java/io/gatehill/imposter/server/ReservedCharsInPathTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/ReservedCharsInPathTest.kt
@@ -45,26 +45,24 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.config.util.EnvVars
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for paths with parameters adjacent to reserved characters.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class ReservedCharsInPathTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
 

--- a/server/src/test/java/io/gatehill/imposter/server/ResponseTemplateTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/ResponseTemplateTest.kt
@@ -46,12 +46,11 @@ import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 
 /**
@@ -59,14 +58,13 @@ import java.io.File
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class ResponseTemplateTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/SecurityConfigRegexTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/SecurityConfigRegexTest.kt
@@ -45,25 +45,23 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.apache.commons.lang3.RandomStringUtils
-import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for security configuration using regular expressions.
  */
-@RunWith(VertxUnitRunner::class)
 class SecurityConfigRegexTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 
@@ -80,7 +78,7 @@ class SecurityConfigRegexTest : BaseVerticleTest() {
             .header("Authorization", "Bearer " + RandomStringUtils.random(50, "ABCDEFGHIJKLMNOPRSTUVXYZabcdefghijklmnoprstuvxyz1234567890"))
             .get("/match")
                 .then()
-                .statusCode(Matchers.equalTo(HttpUtil.HTTP_OK))
+                .statusCode(equalTo(HttpUtil.HTTP_OK))
     }
 
     /**
@@ -92,7 +90,7 @@ class SecurityConfigRegexTest : BaseVerticleTest() {
             .header("Authorization", "Token ")
             .get("/match")
                 .then()
-                .statusCode(Matchers.equalTo(HttpUtil.HTTP_UNAUTHORIZED))
+                .statusCode(equalTo(HttpUtil.HTTP_UNAUTHORIZED))
     }
 
     /**
@@ -104,7 +102,7 @@ class SecurityConfigRegexTest : BaseVerticleTest() {
             .header("Authorization", "Bearer magic-token")
             .get("/does-not-match")
                 .then()
-                .statusCode(Matchers.equalTo(HttpUtil.HTTP_OK))
+                .statusCode(equalTo(HttpUtil.HTTP_OK))
     }
 
     /**
@@ -116,6 +114,6 @@ class SecurityConfigRegexTest : BaseVerticleTest() {
             .header("Authorization", "Bearer bad-token")
             .get("/does-not-match")
                 .then()
-                .statusCode(Matchers.equalTo(HttpUtil.HTTP_UNAUTHORIZED))
+                .statusCode(equalTo(HttpUtil.HTTP_UNAUTHORIZED))
     }
 }

--- a/server/src/test/java/io/gatehill/imposter/server/SecurityConfigTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/SecurityConfigTest.kt
@@ -48,24 +48,25 @@ import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.gatehill.imposter.util.InjectorUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
+ * Tests for security configuration.
+ *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class SecurityConfigTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 
@@ -74,35 +75,35 @@ class SecurityConfigTest : BaseVerticleTest() {
     )
 
     @Test
-    fun testPluginLoadAndConfig(testContext: TestContext) {
+    fun testPluginLoadAndConfig() {
         val pluginManager = InjectorUtil.getInstance<PluginManager>()
         val plugin = pluginManager.getPlugin<TestPluginImpl>(TestPluginImpl::class.java.canonicalName)
-        testContext.assertNotNull(plugin)
-        testContext.assertNotNull(plugin!!.configs)
-        testContext.assertEquals(1, plugin.configs.size)
+        assertNotNull(plugin)
+        assertNotNull(plugin!!.configs)
+        assertEquals(1, plugin.configs.size)
         val pluginConfig = plugin.configs[0]
 
         // check security config
         val securityConfig = pluginConfig.securityConfig
-        testContext.assertNotNull(securityConfig)
-        testContext.assertEquals(SecurityEffect.Deny, securityConfig!!.defaultEffect)
+        assertNotNull(securityConfig)
+        assertEquals(SecurityEffect.Deny, securityConfig!!.defaultEffect)
 
         // check conditions
-        testContext.assertEquals(2, securityConfig.conditions.size)
+        assertEquals(2, securityConfig.conditions.size)
 
         // check short configuration option
         val condition1 = securityConfig.conditions[0]
-        testContext.assertEquals(SecurityEffect.Permit, condition1.effect)
+        assertEquals(SecurityEffect.Permit, condition1.effect)
         val parsedHeaders1 = condition1.requestHeaders
-        testContext.assertEquals(1, parsedHeaders1.size)
-        testContext.assertEquals("s3cr3t", parsedHeaders1["Authorization"]!!.value)
+        assertEquals(1, parsedHeaders1.size)
+        assertEquals("s3cr3t", parsedHeaders1["Authorization"]!!.value)
 
         // check long configuration option
         val condition2 = securityConfig.conditions[1]
-        testContext.assertEquals(SecurityEffect.Deny, condition2.effect)
+        assertEquals(SecurityEffect.Deny, condition2.effect)
         val parsedHeaders2 = condition2.requestHeaders
-        testContext.assertEquals(1, parsedHeaders2.size)
-        testContext.assertEquals("opensesame", parsedHeaders2["X-Api-Key"]!!.value)
+        assertEquals(1, parsedHeaders2.size)
+        assertEquals("opensesame", parsedHeaders2["X-Api-Key"]!!.value)
     }
 
     /**

--- a/server/src/test/java/io/gatehill/imposter/server/SecurityQueryParamsTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/SecurityQueryParamsTest.kt
@@ -45,26 +45,23 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
-import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for security using query parameters.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class SecurityQueryParamsTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
-    @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    @BeforeEach
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 
@@ -79,7 +76,7 @@ class SecurityQueryParamsTest : BaseVerticleTest() {
     fun testRequestDenied_NoAuth() {
         RestAssured.given().`when`().get("/example")
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_UNAUTHORIZED))
+            .statusCode(equalTo(HttpUtil.HTTP_UNAUTHORIZED))
     }
 
     /**
@@ -91,7 +88,7 @@ class SecurityQueryParamsTest : BaseVerticleTest() {
             .queryParam("apiKey", "invalid-value")
             .queryParam("userKey", "opensesame")["/example"]
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_UNAUTHORIZED))
+            .statusCode(equalTo(HttpUtil.HTTP_UNAUTHORIZED))
     }
 
     /**
@@ -103,7 +100,7 @@ class SecurityQueryParamsTest : BaseVerticleTest() {
             .queryParam("apiKey", "s3cr3t")
             .queryParam("userKey", "does-not-match")["/example"]
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_UNAUTHORIZED))
+            .statusCode(equalTo(HttpUtil.HTTP_UNAUTHORIZED))
     }
 
     /**
@@ -114,11 +111,11 @@ class SecurityQueryParamsTest : BaseVerticleTest() {
         RestAssured.given().`when`()
             .queryParam("apiKey", "s3cr3t")["/example"]
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_UNAUTHORIZED))
+            .statusCode(equalTo(HttpUtil.HTTP_UNAUTHORIZED))
         RestAssured.given().`when`()
             .queryParam("userKey", "opensesame")["/example"]
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_UNAUTHORIZED))
+            .statusCode(equalTo(HttpUtil.HTTP_UNAUTHORIZED))
     }
 
     /**
@@ -130,6 +127,6 @@ class SecurityQueryParamsTest : BaseVerticleTest() {
             .queryParam("apiKey", "s3cr3t")
             .queryParam("userKey", "opensesame")["/example"]
             .then()
-            .statusCode(Matchers.equalTo(HttpUtil.HTTP_OK))
+            .statusCode(equalTo(HttpUtil.HTTP_OK))
     }
 }

--- a/server/src/test/java/io/gatehill/imposter/server/SecurityWithResourcesTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/SecurityWithResourcesTest.kt
@@ -45,12 +45,11 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for when resources are configured with no security, so policy
@@ -58,14 +57,12 @@ import org.junit.runner.RunWith
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class SecurityWithResourcesTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
-    @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    @BeforeEach
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
     }
 

--- a/server/src/test/java/io/gatehill/imposter/server/StaticContentTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/StaticContentTest.kt
@@ -44,27 +44,24 @@ package io.gatehill.imposter.server
 
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
-import org.hamcrest.Matchers.containsString
-import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for returning static content.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class StaticContentTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/StepsRemoteTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/StepsRemoteTest.kt
@@ -50,16 +50,14 @@ import io.vertx.core.Vertx
 import io.vertx.core.http.HttpMethod
 import io.vertx.core.http.HttpServerOptions
 import io.vertx.core.http.HttpServerRequest
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matcher
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.AfterClass
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import java.util.function.Consumer
 
@@ -68,14 +66,12 @@ import java.util.function.Consumer
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class StepsRemoteTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
-    @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    @BeforeEach
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }
@@ -129,13 +125,13 @@ class StepsRemoteTest : BaseVerticleTest() {
         private var vertx: Vertx? = null
 
         @JvmStatic
-        @BeforeClass
+        @BeforeAll
         fun beforeClass() {
             vertx = Vertx.vertx()
         }
 
         @JvmStatic
-        @AfterClass
+        @AfterAll
         @Throws(Exception::class)
         fun afterClass() {
             vertx?.close()

--- a/server/src/test/java/io/gatehill/imposter/server/StepsScriptTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/StepsScriptTest.kt
@@ -45,26 +45,24 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for script steps.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class StepsScriptTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/StoreApiTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/StoreApiTest.kt
@@ -46,30 +46,28 @@ import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.any
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasEntry
 import org.hamcrest.Matchers.not
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for stores REST API.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class StoreApiTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/StorePreloadTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/StorePreloadTest.kt
@@ -45,26 +45,23 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for preloading data into storage subsystem.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class StorePreloadTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
-    @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    @BeforeEach
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/StoreScriptTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/StoreScriptTest.kt
@@ -45,26 +45,24 @@ package io.gatehill.imposter.server
 import io.gatehill.imposter.plugin.test.TestPluginImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
-import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for scripted store usage.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class StoreScriptTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }

--- a/server/src/test/java/io/gatehill/imposter/server/TrailingWildcardPathTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/TrailingWildcardPathTest.kt
@@ -43,27 +43,25 @@
 package io.gatehill.imposter.server
 
 import io.gatehill.imposter.plugin.test.TestPluginImpl
+import io.gatehill.imposter.util.HttpUtil
 import io.restassured.RestAssured
-import io.vertx.ext.unit.TestContext
-import io.vertx.ext.unit.junit.VertxUnitRunner
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for matching request path with a trailing wildcard.
  *
  * @author Pete Cornish
  */
-@RunWith(VertxUnitRunner::class)
 class TrailingWildcardPathTest : BaseVerticleTest() {
     override val pluginClass = TestPluginImpl::class.java
 
-    @Before
-    @Throws(Exception::class)
-    override fun setUp(testContext: TestContext) {
-        super.setUp(testContext)
+    @BeforeEach
+    override fun setUp(vertx: Vertx, testContext: VertxTestContext) {
+        super.setUp(vertx, testContext)
         RestAssured.baseURI = "http://$host:$listenPort"
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
     }
@@ -77,7 +75,7 @@ class TrailingWildcardPathTest : BaseVerticleTest() {
         RestAssured.given().`when`()
             .get("/")
             .then()
-            .statusCode(equalTo(200))
+            .statusCode(equalTo(HttpUtil.HTTP_OK))
             .body(equalTo("Matched wildcard path"))
     }
 
@@ -86,7 +84,7 @@ class TrailingWildcardPathTest : BaseVerticleTest() {
         RestAssured.given().`when`()
             .get("/subpath")
             .then()
-            .statusCode(equalTo(200))
+            .statusCode(equalTo(HttpUtil.HTTP_OK))
             .body(equalTo("Matched wildcard path"))
     }
 
@@ -95,7 +93,7 @@ class TrailingWildcardPathTest : BaseVerticleTest() {
         RestAssured.given().`when`()
             .get("/exact")
             .then()
-            .statusCode(equalTo(200))
+            .statusCode(equalTo(HttpUtil.HTTP_OK))
             .body(equalTo("Matched exact path"))
     }
 }

--- a/store/common/build.gradle
+++ b/store/common/build.gradle
@@ -10,7 +10,8 @@ dependencies {
     api project(':core:imposter-engine')
 
     // test
-    testImplementation "junit:junit:$version_junit"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$version_junit_jupiter"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$version_junit_jupiter"
     testImplementation "org.mockito:mockito-core:$version_mockito"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$version_mockito_kotlin"
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: version_hamcrest
@@ -61,4 +62,8 @@ compileTestKotlin {
         // see https://kotlinlang.org/docs/java-to-kotlin-interop.html#default-methods-in-interfaces
         freeCompilerArgs = ["-Xjvm-default=all"]
     }
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/store/common/src/main/java/io/gatehill/imposter/store/service/CaptureServiceImpl.kt
+++ b/store/common/src/main/java/io/gatehill/imposter/store/service/CaptureServiceImpl.kt
@@ -92,11 +92,11 @@ class CaptureServiceImpl @Inject constructor(
         httpExchange: HttpExchange,
         phaseFilter: ExchangePhase,
     ) {
-        if (resourceConfig is CaptureConfigHolder) {
-            val captureConfig = (resourceConfig as CaptureConfigHolder).captureConfig
-            captureConfig?.let {
-                captureConfig.filterValues { it.enabled && it.phase == phaseFilter }
-                    .forEach { (captureConfigKey: String, itemConfig: ItemCaptureConfig) ->
+        when (resourceConfig) {
+            is CaptureConfigHolder -> {
+                resourceConfig.captureConfig
+                    ?.filterValues { it.enabled && it.phase == phaseFilter }
+                    ?.forEach { (captureConfigKey: String, itemConfig: ItemCaptureConfig) ->
                         captureItem(captureConfigKey, itemConfig, httpExchange, PlaceholderUtil.defaultEvaluators)
                     }
             }

--- a/store/common/src/test/java/io/gatehill/imposter/store/model/PrefixedKeyStoreTest.kt
+++ b/store/common/src/test/java/io/gatehill/imposter/store/model/PrefixedKeyStoreTest.kt
@@ -47,9 +47,9 @@ import io.gatehill.imposter.store.core.PrefixedKeyStore
 import io.gatehill.imposter.store.inmem.InMemoryStore
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [PrefixedKeyStore].
@@ -60,8 +60,7 @@ class PrefixedKeyStoreTest {
     private var delegateStore: InMemoryStore? = null
     private var store: PrefixedKeyStore? = null
 
-    @Before
-    @Throws(Exception::class)
+    @BeforeEach
     fun setUp() {
         delegateStore = InMemoryStore(
             DeferredOperationService(),
@@ -74,8 +73,8 @@ class PrefixedKeyStoreTest {
     @Test
     fun testPrefixedKeys() {
         store!!.save("foo", "bar")
-        Assert.assertTrue(delegateStore!!.hasItemWithKey("pref.foo"))
-        Assert.assertEquals(store!!.load("foo"), "bar")
+        Assertions.assertTrue(delegateStore!!.hasItemWithKey("pref.foo"))
+        Assertions.assertEquals(store!!.load("foo"), "bar")
 
         // prefix should not be present in keys
         val allKeys: Set<String?> = store!!.loadAll().keys

--- a/store/common/src/test/java/io/gatehill/imposter/store/service/CaptureServiceImplTest.kt
+++ b/store/common/src/test/java/io/gatehill/imposter/store/service/CaptureServiceImplTest.kt
@@ -52,7 +52,7 @@ import io.gatehill.imposter.store.core.Store
 import io.gatehill.imposter.store.factory.StoreFactory
 import io.gatehill.imposter.util.DateTimeUtil
 import io.gatehill.imposter.util.PlaceholderUtil
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq

--- a/store/dynamodb/src/test/java/io/gatehill/imposter/store/dynamodb/DynamoDBStoreFactoryImplTest.kt
+++ b/store/dynamodb/src/test/java/io/gatehill/imposter/store/dynamodb/DynamoDBStoreFactoryImplTest.kt
@@ -51,10 +51,10 @@ import io.gatehill.imposter.store.dynamodb.config.Settings
 import io.gatehill.imposter.store.dynamodb.support.DynamoDBStoreTestHelper
 import io.gatehill.imposter.store.support.Example
 import io.gatehill.imposter.util.TestEnvironmentUtil
-import org.junit.AfterClass
-import org.junit.Assert
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import org.testcontainers.containers.localstack.LocalStackContainer
 
 /**
@@ -69,7 +69,7 @@ class DynamoDBStoreFactoryImplTest : AbstractStoreFactoryTest() {
         private val helper = DynamoDBStoreTestHelper()
         private var dynamo: LocalStackContainer? = null
 
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUp() {
             // These tests need Docker
@@ -86,7 +86,7 @@ class DynamoDBStoreFactoryImplTest : AbstractStoreFactoryTest() {
             helper.createTable("Imposter")
         }
 
-        @AfterClass
+        @AfterAll
         @JvmStatic
         fun tearDown() {
             try {
@@ -110,14 +110,14 @@ class DynamoDBStoreFactoryImplTest : AbstractStoreFactoryTest() {
         )
 
         val store = factory.buildNewStore("complex-binary")
-        Assert.assertEquals(0, store.count())
+        Assertions.assertEquals(0, store.count())
         store.save("garply", Example("test"))
 
         // POJO is deserialised as a Map
         val loadedMap = store.load<Map<String, *>>("garply")
-        Assert.assertNotNull(loadedMap)
-        Assert.assertTrue("Returned value should be a Map", loadedMap is Map)
-        Assert.assertEquals("test", loadedMap!!["name"])
+        Assertions.assertNotNull(loadedMap)
+        Assertions.assertTrue(loadedMap is Map, "Returned value should be a Map")
+        Assertions.assertEquals("test", loadedMap!!["name"])
     }
 
     /**
@@ -130,13 +130,13 @@ class DynamoDBStoreFactoryImplTest : AbstractStoreFactoryTest() {
         )
 
         val store = factory.buildNewStore("complex-map")
-        Assert.assertEquals(0, store.count())
+        Assertions.assertEquals(0, store.count())
         store.save("garply", Example("test"))
 
         // POJO is deserialised as a Map
         val loadedMap = store.load<Map<String, *>>("garply")
-        Assert.assertNotNull(loadedMap)
-        Assert.assertTrue("Returned value should be a Map", loadedMap is Map)
-        Assert.assertEquals("test", loadedMap!!["name"])
+        Assertions.assertNotNull(loadedMap)
+        Assertions.assertTrue(loadedMap is Map, "Returned value should be a Map")
+        Assertions.assertEquals("test", loadedMap!!["name"])
     }
 }

--- a/store/dynamodb/src/test/java/io/gatehill/imposter/store/dynamodb/DynamoDBStoreTtlTest.kt
+++ b/store/dynamodb/src/test/java/io/gatehill/imposter/store/dynamodb/DynamoDBStoreTtlTest.kt
@@ -51,12 +51,12 @@ import io.gatehill.imposter.service.DeferredOperationService
 import io.gatehill.imposter.store.dynamodb.support.DynamoDBStoreTestHelper
 import io.gatehill.imposter.store.factory.AbstractStoreFactory
 import io.gatehill.imposter.util.TestEnvironmentUtil
-import org.junit.AfterClass
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.testcontainers.containers.localstack.LocalStackContainer
 import java.nio.file.Files
 
@@ -73,7 +73,7 @@ class DynamoDBStoreTtlTest {
         private val helper = DynamoDBStoreTestHelper()
         private var dynamo: LocalStackContainer? = null
 
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUp() {
             // These tests need Docker
@@ -90,7 +90,7 @@ class DynamoDBStoreTtlTest {
             helper.createTable("TtlTest")
         }
 
-        @AfterClass
+        @AfterAll
         @JvmStatic
         fun tearDown() {
             try {
@@ -102,7 +102,7 @@ class DynamoDBStoreTtlTest {
         }
     }
 
-    @Before
+    @BeforeEach
     fun before() {
         val configDir = Files.createTempDirectory("imposter")
 
@@ -127,13 +127,13 @@ class DynamoDBStoreTtlTest {
             )
         )
 
-        assertNotNull("Item should exist", item?.item)
+        assertNotNull(item?.item, "Item should exist")
 
         val ttlAttribute = item.item["ttl"]
-        assertNotNull("TTL attribute should exist", ttlAttribute)
+        assertNotNull(ttlAttribute, "TTL attribute should exist")
 
         val ttlValue = ttlAttribute!!.n
-        assertNotNull("TTL should be set to number", ttlValue)
-        assertTrue("TTL should be persistence time + configured value", ttlValue.toLong() >= (persistenceTime + ttlSeconds))
+        assertNotNull(ttlValue, "TTL should be set to number")
+        assertTrue(ttlValue.toLong() >= (persistenceTime + ttlSeconds), "TTL should be persistence time + configured value")
     }
 }

--- a/store/graphql/build.gradle
+++ b/store/graphql/build.gradle
@@ -19,7 +19,8 @@ dependencies {
     pluginImplementation("com.apurebase:kgraphql:$version_kgraphql")
 
     // test
-    testImplementation "junit:junit:$version_junit"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$version_junit_jupiter"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$version_junit_jupiter"
     testImplementation "org.mockito:mockito-core:$version_mockito"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$version_mockito_kotlin"
     testImplementation project(':store:store-inmem')
@@ -52,4 +53,8 @@ shadowJar {
 
 task dist {
     dependsOn shadowJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/store/graphql/src/test/java/io/gatehill/imposter/store/redis/GraphQLQueryServiceTest.kt
+++ b/store/graphql/src/test/java/io/gatehill/imposter/store/redis/GraphQLQueryServiceTest.kt
@@ -51,10 +51,10 @@ import io.gatehill.imposter.store.inmem.InMemoryStoreFactoryImpl
 import io.gatehill.imposter.util.HttpUtil
 import io.vertx.core.json.JsonObject
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
@@ -75,7 +75,7 @@ class GraphQLQueryServiceTest {
     private lateinit var httpExchange: HttpExchange
     private lateinit var httpResponse: HttpResponse
 
-    @Before
+    @BeforeEach
     fun before() {
         storeFactory = InMemoryStoreFactoryImpl(mock())
         service = GraphQLQueryService(storeFactory, EngineLifecycleHooks())
@@ -110,10 +110,10 @@ class GraphQLQueryServiceTest {
 
         val json = JsonObject(body)
         val graphQlData = json.getJsonObject("data")
-        assertNotNull("GraphQL data property should exist", graphQlData)
+        assertNotNull(graphQlData, "GraphQL data property should exist")
 
         val items = graphQlData.getJsonArray("items")
-        assertNotNull("Items should be present in GraphQL response", items)
+        assertNotNull(items, "Items should be present in GraphQL response")
         assertEquals(2, items.size())
 
         val firstItem = items.mapIndexedNotNull { i, _ -> items.getJsonObject(i) }
@@ -146,10 +146,10 @@ class GraphQLQueryServiceTest {
 
         val json = JsonObject(body)
         val graphQlData = json.getJsonObject("data")
-        assertNotNull("GraphQL data property should exist", graphQlData)
+        assertNotNull(graphQlData, "GraphQL data property should exist")
 
         val items = graphQlData.getJsonArray("items")
-        assertNotNull("Items should be present in GraphQL response", items)
+        assertNotNull(items, "Items should be present in GraphQL response")
         assertEquals(1, items.size())
 
         val firstItem = items.getJsonObject(0)

--- a/store/redis/src/test/java/io/gatehill/imposter/store/redis/RedisStoreFactoryImplTest.kt
+++ b/store/redis/src/test/java/io/gatehill/imposter/store/redis/RedisStoreFactoryImplTest.kt
@@ -46,8 +46,8 @@ import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.service.DeferredOperationService
 import io.gatehill.imposter.store.AbstractStoreFactoryTest
 import io.gatehill.imposter.util.TestEnvironmentUtil
-import org.junit.AfterClass
-import org.junit.BeforeClass
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
@@ -68,7 +68,7 @@ class RedisStoreFactoryImplTest : AbstractStoreFactoryTest() {
         private var redis: GenericContainer<*>? = null
         private var imposterConfig: ImposterConfig? = null
 
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         @Throws(Exception::class)
         fun setUp() {
@@ -85,7 +85,7 @@ class RedisStoreFactoryImplTest : AbstractStoreFactoryTest() {
             }
         }
 
-        @AfterClass
+        @AfterAll
         @JvmStatic
         fun tearDown() {
             try {

--- a/test/test-utils/build.gradle
+++ b/test/test-utils/build.gradle
@@ -12,8 +12,9 @@ dependencies {
     implementation project(':core:config-dynamic')
 
     // test
-    api "junit:junit:$version_junit"
-    api "io.vertx:vertx-unit:$version_vertx"
+    api "org.junit.jupiter:junit-jupiter-api:$version_junit_jupiter"
+    api "org.junit.jupiter:junit-jupiter-engine:$version_junit_jupiter"
+    api "io.vertx:vertx-junit5:$version_vertx"
     api group: 'org.hamcrest', name: 'hamcrest', version: version_hamcrest
 
     // logging

--- a/test/test-utils/src/main/java/io/gatehill/imposter/scripting/AbstractBaseScriptTest.kt
+++ b/test/test-utils/src/main/java/io/gatehill/imposter/scripting/AbstractBaseScriptTest.kt
@@ -57,9 +57,9 @@ import io.gatehill.imposter.util.FeatureUtil
 import io.gatehill.imposter.util.InjectorUtil
 import io.gatehill.imposter.util.MetricsUtil
 import org.apache.logging.log4j.LogManager
-import org.junit.AfterClass
-import org.junit.Before
-import org.junit.BeforeClass
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.mockito.Mockito.mock
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -72,19 +72,19 @@ import org.mockito.Mockito.`when` as When
 abstract class AbstractBaseScriptTest {
     companion object {
         @JvmStatic
-        @BeforeClass
+        @BeforeAll
         fun beforeClass() {
             FeatureUtil.disableFeature(MetricsUtil.FEATURE_NAME_METRICS)
         }
 
         @JvmStatic
-        @AfterClass
+        @AfterAll
         fun afterClass() {
             FeatureUtil.clearSystemPropertyOverrides()
         }
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         onBeforeInject()
         InjectorUtil.create(*modules).injectMembers(this)

--- a/test/test-utils/src/main/java/io/gatehill/imposter/scripting/AbstractContextPropertiesTest.kt
+++ b/test/test-utils/src/main/java/io/gatehill/imposter/scripting/AbstractContextPropertiesTest.kt
@@ -43,9 +43,9 @@
 package io.gatehill.imposter.scripting
 
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
 
 /**
  * Verify that scripts can access properties of the context.

--- a/test/test-utils/src/main/java/io/gatehill/imposter/scripting/AbstractScriptServiceImplTest.kt
+++ b/test/test-utils/src/main/java/io/gatehill/imposter/scripting/AbstractScriptServiceImplTest.kt
@@ -47,10 +47,10 @@ import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.script.ReadWriteResponseBehaviour
 import io.gatehill.imposter.script.ResponseBehaviourType
 import io.gatehill.imposter.service.ScriptSource
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
 import java.util.*
 import kotlin.io.path.readText
 
@@ -104,7 +104,7 @@ abstract class AbstractScriptServiceImplTest : AbstractBaseScriptTest() {
         // zero as un-set by script
         assertEquals(0, actual.statusCode)
         assertNull(actual.responseFile)
-        assertNull("Behaviour type should not be set", actual.behaviourType)
+        assertNull(actual.behaviourType, "Behaviour type should not be set")
     }
 
     @Test
@@ -123,7 +123,7 @@ abstract class AbstractScriptServiceImplTest : AbstractBaseScriptTest() {
 
         assertNotNull(actual)
         assertEquals(203, actual.statusCode)
-        assertNull("Behaviour type should not be set", actual.behaviourType)
+        assertNull(actual.behaviourType, "Behaviour type should not be set")
         assertEquals("quux", actual.responseHeaders["X-Echo-Qux"])
     }
 
@@ -143,7 +143,7 @@ abstract class AbstractScriptServiceImplTest : AbstractBaseScriptTest() {
 
         assertNotNull(actual)
         assertEquals(200, actual.statusCode)
-        assertNull("Behaviour type should not be set", actual.behaviourType)
+        assertNull(actual.behaviourType, "Behaviour type should not be set")
         assertEquals("bar", actual.responseHeaders["X-Echo-Foo"])
     }
 
@@ -163,7 +163,7 @@ abstract class AbstractScriptServiceImplTest : AbstractBaseScriptTest() {
 
         assertNotNull(actual)
         assertEquals(202, actual.statusCode)
-        assertNull("Behaviour type should not be set", actual.behaviourType)
+        assertNull(actual.behaviourType, "Behaviour type should not be set")
         assertEquals("qux", actual.responseHeaders["X-Echo-Baz"])
     }
 
@@ -185,7 +185,7 @@ abstract class AbstractScriptServiceImplTest : AbstractBaseScriptTest() {
 
         assertNotNull(actual)
         assertEquals(202, actual.statusCode)
-        assertNull("Behaviour type should not be set", actual.behaviourType)
+        assertNull(actual.behaviourType, "Behaviour type should not be set")
         assertEquals("grault", actual.responseHeaders["X-Echo-Corge"])
     }
 
@@ -207,7 +207,7 @@ abstract class AbstractScriptServiceImplTest : AbstractBaseScriptTest() {
 
         assertNotNull(actual)
         assertEquals(204, actual.statusCode)
-        assertNull("Behaviour type should not be set", actual.behaviourType)
+        assertNull(actual.behaviourType, "Behaviour type should not be set")
         assertEquals("foo", actual.responseHeaders["X-Echo-Env-Var"])
     }
 

--- a/test/test-utils/src/main/java/io/gatehill/imposter/server/VerticleTestCategory.kt
+++ b/test/test-utils/src/main/java/io/gatehill/imposter/server/VerticleTestCategory.kt
@@ -1,0 +1,14 @@
+package io.gatehill.imposter.server
+
+import org.junit.jupiter.api.Tag
+
+/**
+ * Marker annotation for tests that extend BaseVerticleTest.
+ * Used to categorise and run these tests specifically.
+ *
+ * @author Pete Cornish
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Tag("verticle")
+annotation class VerticleTest

--- a/test/test-utils/src/main/java/io/gatehill/imposter/server/engine/JvmMockEngine.kt
+++ b/test/test-utils/src/main/java/io/gatehill/imposter/server/engine/JvmMockEngine.kt
@@ -45,22 +45,15 @@ package io.gatehill.imposter.server.engine
 
 import io.gatehill.imposter.server.ImposterVerticle
 import io.vertx.core.Vertx
-import io.vertx.ext.unit.Async
-import io.vertx.ext.unit.TestContext
+import io.vertx.junit5.VertxTestContext
 
 /**
  * JVM-based mock engine.
  */
 class JvmMockEngine : TestMockEngine {
-    override fun start(vertx: Vertx, host: String, async: Async, testContext: TestContext) {
+    override fun start(vertx: Vertx, host: String, testContext: VertxTestContext) {
         // simulate ImposterLauncher bootstrap
-        vertx.deployVerticle(ImposterVerticle::class.java.canonicalName) { completion ->
-            if (completion.succeeded()) {
-                async.complete()
-            } else {
-                testContext.fail(completion.cause())
-            }
-        }
+        vertx.deployVerticle(ImposterVerticle::class.java.canonicalName, testContext.succeedingThenComplete())
     }
 
     override fun stop() {

--- a/test/test-utils/src/main/java/io/gatehill/imposter/server/engine/TestMockEngine.kt
+++ b/test/test-utils/src/main/java/io/gatehill/imposter/server/engine/TestMockEngine.kt
@@ -44,10 +44,9 @@
 package io.gatehill.imposter.server.engine
 
 import io.vertx.core.Vertx
-import io.vertx.ext.unit.Async
-import io.vertx.ext.unit.TestContext
+import io.vertx.junit5.VertxTestContext
 
 interface TestMockEngine {
-    fun start(vertx: Vertx, host: String, async: Async, testContext: TestContext)
+    fun start(vertx: Vertx, host: String, testContext: VertxTestContext)
     fun stop()
 }

--- a/test/test-utils/src/main/java/io/gatehill/imposter/store/AbstractStoreFactoryTest.kt
+++ b/test/test-utils/src/main/java/io/gatehill/imposter/store/AbstractStoreFactoryTest.kt
@@ -45,9 +45,9 @@ package io.gatehill.imposter.store
 import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.store.factory.AbstractStoreFactory
 import io.gatehill.imposter.store.support.Example
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.nio.file.Files
 
 /**
@@ -59,7 +59,7 @@ abstract class AbstractStoreFactoryTest {
     protected lateinit var factory: AbstractStoreFactory
     protected abstract val typeDescription: String
 
-    @Before
+    @BeforeEach
     fun before() {
         val configDir = Files.createTempDirectory("imposter")
 
@@ -73,7 +73,7 @@ abstract class AbstractStoreFactoryTest {
     @Test
     fun testBuildNewStore() {
         val store = factory.buildNewStore("test")
-        Assert.assertEquals(typeDescription, store.typeDescription)
+        Assertions.assertEquals(typeDescription, store.typeDescription)
     }
 
     @Test
@@ -81,70 +81,70 @@ abstract class AbstractStoreFactoryTest {
         factory.clearStore("sli", false)
         val store = factory.buildNewStore("sli")
 
-        Assert.assertEquals(0, store.count())
+        Assertions.assertEquals(0, store.count())
         store.save("foo", "bar")
         store.save("baz", 123L)
         store.save("qux", true)
         store.save("corge", null)
 
-        Assert.assertEquals("bar", store.load("foo"))
-        Assert.assertEquals(123L, store.load("baz"))
-        Assert.assertEquals(true, store.load("qux"))
-        Assert.assertNull(store.load("corge"))
+        Assertions.assertEquals("bar", store.load("foo"))
+        Assertions.assertEquals(123L, store.load("baz"))
+        Assertions.assertEquals(true, store.load("qux"))
+        Assertions.assertNull(store.load("corge"))
 
         val allItems = store.loadAll()
-        Assert.assertEquals("bar", allItems["foo"])
-        Assert.assertEquals(123L, allItems["baz"])
-        Assert.assertEquals(true, allItems["qux"])
-        Assert.assertNull(allItems["corge"])
-        Assert.assertTrue("Item should exist", store.hasItemWithKey("foo"))
+        Assertions.assertEquals("bar", allItems["foo"])
+        Assertions.assertEquals(123L, allItems["baz"])
+        Assertions.assertEquals(true, allItems["qux"])
+        Assertions.assertNull(allItems["corge"])
+        Assertions.assertTrue(store.hasItemWithKey("foo"), "Item should exist")
     }
 
     @Test
     fun testLoadByKeyPrefix() {
         val store = factory.buildNewStore("kp")
-        Assert.assertEquals(0, store.count())
+        Assertions.assertEquals(0, store.count())
         store.save("foo_one", "bar")
         store.save("foo_two", "baz")
 
         val items = store.loadByKeyPrefix("foo_")
-        Assert.assertEquals("bar", items["foo_one"])
-        Assert.assertEquals("baz", items["foo_two"])
+        Assertions.assertEquals("bar", items["foo_one"])
+        Assertions.assertEquals("baz", items["foo_two"])
     }
 
     @Test
     fun testSaveLoadMap() {
         val store = factory.buildNewStore("map")
-        Assert.assertEquals(0, store.count())
+        Assertions.assertEquals(0, store.count())
         store.save("grault", mapOf("foo" to "bar"))
 
         val loadedMap = store.load<Map<String, *>>("grault")
-        Assert.assertNotNull(loadedMap)
-        Assert.assertTrue("Returned value should be a Map", loadedMap is Map)
-        Assert.assertEquals("bar", loadedMap!!["foo"])
+        Assertions.assertNotNull(loadedMap)
+        Assertions.assertTrue(loadedMap is Map, "Returned value should be a Map")
+        Assertions.assertEquals("bar", loadedMap!!["foo"])
     }
 
     @Test
     open fun testSaveLoadComplexItemBinary() {
         val store = factory.buildNewStore("complex-binary")
-        Assert.assertEquals(0, store.count())
+        Assertions.assertEquals(0, store.count())
         store.save("garply", Example("test"))
 
         // POJO is deserialised as a Map
         val loaded = store.load<Example>("garply")
-        Assert.assertNotNull(loaded)
-        Assert.assertTrue("Returned value should be a ${Example::class.qualifiedName}", loaded is Example)
-        Assert.assertEquals("test", loaded!!.name)
+        Assertions.assertNotNull(loaded)
+        Assertions.assertTrue(loaded is Example, "Returned value should be a ${Example::class.qualifiedName}")
+        Assertions.assertEquals("test", loaded!!.name)
     }
 
     @Test
     fun testDeleteItem() {
         val store = factory.buildNewStore("di")
-        Assert.assertFalse("Item should not exist", store.hasItemWithKey("baz"))
+        Assertions.assertFalse(store.hasItemWithKey("baz"), "Item should not exist")
         store.save("baz", "qux")
-        Assert.assertTrue("Item should exist", store.hasItemWithKey("baz"))
+        Assertions.assertTrue(store.hasItemWithKey("baz"), "Item should exist")
         store.delete("baz")
-        Assert.assertFalse("Item should not exist", store.hasItemWithKey("baz"))
+        Assertions.assertFalse(store.hasItemWithKey("baz"), "Item should not exist")
     }
 
     @Test
@@ -152,6 +152,6 @@ abstract class AbstractStoreFactoryTest {
         val store = factory.buildNewStore("ds")
         store.save("baz", "qux")
         factory.clearStore("ds", false)
-        Assert.assertEquals("Store should be empty", 0, factory.getStoreByName("ds", false).count())
+        Assertions.assertEquals(0, factory.getStoreByName("ds", false).count(), "Store should be empty")
     }
 }

--- a/test/test-utils/src/main/java/io/gatehill/imposter/util/TestEnvironmentUtil.kt
+++ b/test/test-utils/src/main/java/io/gatehill/imposter/util/TestEnvironmentUtil.kt
@@ -42,8 +42,7 @@
  */
 package io.gatehill.imposter.util
 
-import org.hamcrest.CoreMatchers
-import org.junit.Assume
+import org.junit.jupiter.api.Assumptions.*
 import java.io.File
 
 /**
@@ -58,7 +57,7 @@ object TestEnvironmentUtil {
      * Skips a JUnit test if Docker is not accessible.
      */
     fun assumeDockerAccessible() {
-        Assume.assumeThat("Docker is running", testDockerRunning(), CoreMatchers.`is`(0))
+        assumeTrue(testDockerRunning() == 0, "Docker is running")
     }
 
     /**
@@ -89,6 +88,6 @@ object TestEnvironmentUtil {
      * Skips a JUnit test if Java version does not meet expectations.
      */
     fun assumeJavaVersionLessThanOrEqualTo(majorVersion: Int) {
-        Assume.assumeTrue(getJvmVersion() <= majorVersion)
+        assumeTrue(getJvmVersion() <= majorVersion)
     }
 }


### PR DESCRIPTION
Replaces the remaining JUnit 4 references, and vertx-unit dependency with JUnit 5 and vertx-junit5.

Also adds a test category for running only the server-type tests (i.e.verticle tests).