### PR TITLE
docs: add GitHub issue templates for bug reports, features and questions.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Report a problem with Imposter
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the form below so we can help you as quickly as possible.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: When I do X, Y happens instead of Z.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Start Imposter with '...'
+        2. Send a request to '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened? Include any error messages or logs.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Imposter version
+      description: Which version of Imposter are you running? (e.g. output of `imposter --version`)
+      placeholder: e.g. 4.5.0
+    validations:
+      required: true
+  - type: dropdown
+    id: distribution
+    attributes:
+      label: How are you running Imposter?
+      options:
+        - CLI
+        - Docker
+        - JAR
+        - AWS Lambda
+        - Kubernetes
+        - Embedded (JVM)
+        - Embedded (Node.js)
+        - Other
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Operating system, JVM version, etc.
+      placeholder: |
+        - OS: macOS 14.5
+        - JVM: OpenJDK 21
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context, configuration files, or screenshots that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Imposter documentation
+    url: https://docs.imposter.sh/
+    about: Please check the documentation before opening an issue.
+  - name: GitHub Discussions
+    url: https://github.com/orgs/imposter-project/discussions
+    about: For general discussion, ideas, and community Q&A.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature request
+description: Suggest an idea or enhancement for Imposter
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature! Please describe your idea below.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of the problem. Ex. I'm always frustrated when [...]
+    validations:
+      required: false
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Imposter version (optional)
+      description: Which version of Imposter are you using?
+      placeholder: e.g. 4.5.0
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context, mockups, or screenshots about the feature request here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,38 @@
+name: Question
+description: Ask a question about using Imposter
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question about Imposter? Please check the [documentation](https://docs.imposter.sh/) first, and then fill out the form below.
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What would you like to know?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What are you trying to achieve? Include any relevant configuration or examples.
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Imposter version (optional)
+      description: Which version of Imposter are you using?
+      placeholder: e.g. 4.5.0
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context that might be helpful.
+    validations:
+      required: false


### PR DESCRIPTION
Bug reports require the Imposter version; feature requests and questions
mark it as optional. Also disables blank issues and adds links to the
documentation and discussions.