### PR TITLE
ci: test docs site on every push, restrict deploy to main

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,16 +1,52 @@
 name: Docs site
 on:
   push:
-    branches:
-      - main
-      - develop
   pull_request:
     paths:
       - docs/**
       - mkdocs.yml
+      - scripts/local-docs.sh
       - .github/workflows/docs.yaml
+
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build and serve docs site (detached)
+        run: DETACH=1 scripts/local-docs.sh
+
+      - name: Wait for docs site to be reachable
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8000/ >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "docs site did not become reachable" >&2
+          docker logs imposter-docs || true
+          exit 1
+
+      - name: Verify docs site content
+        run: |
+          curl -fsS http://localhost:8000/ | grep -q "Imposter"
+          curl -fsS http://localhost:8000/grpc_plugin/ | grep -q "gRPC"
+
+      - name: Verify mermaid diagrams are recognised
+        run: |
+          curl -fsS http://localhost:8000/deployment_patterns/ \
+            | grep -q 'class="mermaid"'
+
+      - name: Stop docs container
+        if: always()
+        run: docker rm -f imposter-docs || true
+
   deploy:
+    needs: test
+    if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -26,13 +62,5 @@ jobs:
           PIP_CONSTRAINT: ./docs/infrastructure/constraints.txt
         run: pip install -r ./docs/infrastructure/requirements.txt
 
-      - name: Build static site
-        run: mkdocs build
-
-      - name: Verify mermaid diagrams are recognised
-        run: |
-          grep -q 'class="mermaid"' site/deployment_patterns/index.html
-
       - name: Deploy to GitHub Pages
-        if: ${{ github.ref_name == 'main' }}
         run: mkdocs gh-deploy --force

--- a/scripts/local-docs.sh
+++ b/scripts/local-docs.sh
@@ -45,16 +45,26 @@
 set -e
 
 # This script is used to view the documentation site locally.
+#
+# Set DETACH=1 to run the container in the background (for CI/scripted use).
+# The container is named "imposter-docs" so callers can stop it with
+# `docker rm -f imposter-docs`.
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="$( cd "${SCRIPT_DIR}"/../ && pwd )"
+
+if [[ "${DETACH:-}" == "1" ]]; then
+  RUN_OPTS=(--rm -d --name=imposter-docs)
+else
+  RUN_OPTS=(--rm -it --name=imposter-docs)
+fi
 
 docker build \
   --file="${ROOT_DIR}/docs/infrastructure/Dockerfile" \
   --tag=imposter-docs \
   "${ROOT_DIR}/docs"
 
-docker run --rm -it -p 8000:8000 \
+docker run "${RUN_OPTS[@]}" -p 8000:8000 \
   -v "${ROOT_DIR}/mkdocs.yml:/docs/mkdocs.yml:ro" \
   -v "${ROOT_DIR}/docs:/docs/docs:ro" \
   imposter-docs


### PR DESCRIPTION
Splits the docs workflow into a per-push test job and a main-only deploy job, so docs deployment can no longer be triggered from non-main branches.

## Summary
- `test` job runs on every push and on docs-related PRs. It builds and serves the docs via \`scripts/local-docs.sh\` (now supporting \`DETACH=1\`) and curls a handful of pages (home, gRPC plugin, deployment patterns) to verify the site renders.
- `deploy` job runs only on \`push\` events to \`main\` (gated at the job level), depends on the test job, and runs \`mkdocs gh-deploy --force\` as before.
- \`scripts/local-docs.sh\` gains a \`DETACH=1\` env var to support CI/scripted use; default interactive behaviour is unchanged. Container is named \`imposter-docs\` so callers can clean it up with \`docker rm -f\`.

## Implementation details
The previous workflow guarded only the final \`Deploy to GitHub Pages\` step with \`if: github.ref_name == 'main'\`, but the job itself still ran on \`develop\` pushes and any PR — including running \`mkdocs build\`. Splitting into two jobs makes the boundary unambiguous: a non-main push physically cannot reach the deploy job.

The mermaid-class check now runs against the live served site (\`curl /deployment_patterns/\`) rather than the built static output, which keeps the verification in one place.