### PR TITLE
docs: describe 'log' resource property

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -245,6 +245,58 @@ Imposter allows you to capture elements of the request. You can use these elemen
 
 See [data capture](./data_capture.md) for more information.
 
+## Logging a message
+
+> **Available in Imposter 5 and later**
+
+Add a `log` property to a resource to write a message to Imposter's log whenever the resource is matched. This is useful for tracing which resources are being hit, or for surfacing key request details during development and testing.
+
+```yaml
+plugin: rest
+
+resources:
+  - method: POST
+    path: /hello
+    log: "hello world"
+    response:
+      content: "Hello, world!"
+```
+
+Each time a request matches the resource, the message is written to the log:
+
+```
+hello world
+```
+
+The message supports the same [template placeholders](./templates.md) as response content, so you can include details from the request:
+
+```yaml
+plugin: rest
+
+resources:
+  - method: POST
+    path: /orders/{orderId}
+    log: "received order ${context.request.pathParams.orderId} from ${context.request.headers.X-Client-ID}"
+    response:
+      statusCode: 201
+```
+
+The message is logged after the request has been matched and any [data capture](./data_capture.md) and [steps](./steps.md) have run, so it can reference values they produce.
+
+### Logging from interceptors
+
+[Interceptors](./interceptors.md) also support the `log` property. The message is logged whenever the interceptor matches, whether the interceptor short-circuits the response or allows processing to continue.
+
+```yaml
+plugin: rest
+
+interceptors:
+  - method: POST
+    path: /orders/{orderId}
+    log: "intercepted order ${context.request.pathParams.orderId}"
+    continue: true
+```
+
 ## Environment variables
 
 You can use environment variables as placeholders in plugin configuration files.

--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -116,6 +116,10 @@ The second interceptor has a [script step](./steps.md). Within the script, `resp
 
 Both interceptors store data, which is later used by the `/example` resource.
 
+## Logging a message
+
+Interceptors support the `log` property to write a templated message to Imposter's log whenever they match. See [logging a message](./configuration.md#logging-a-message) for details.
+
 ## Examples
 
 See the following examples:


### PR DESCRIPTION
Document the `log` property available on resources and interceptors (Imposter 5 and later).

Closes #742

## Summary
- Add a "Logging a message" section to the configuration guide describing the `log` resource property, with a simple example and a templated example.
- Note that the message supports the same template placeholders as response content and is logged after data capture and steps run.
- Document that interceptors also support `log`, including when they continue processing, and cross-link from the interceptors guide.