### PR TITLE
docs: document default plugin configuration in CLI

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -60,6 +60,16 @@ For example:
 
 This will install the plugin version matching the current engine version used by the CLI. The next time you run `imposter up`, the plugin will be available.
 
+### Configuring default plugins
+
+You can list plugins in your `.imposter.yaml` file (in the config directory) or in your global CLI config at `$HOME/.imposter/config.yaml`, so they are automatically installed when you run `imposter up`:
+
+```yaml
+plugins:
+  - store-dynamodb
+  - store-redis
+```
+
 ## Using the Docker image
 
 If you are using the [Docker image](./run_imposter_docker.md), you can bind-mount a local directory to the `/opt/imposter/plugins` directory within the container.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -60,7 +60,7 @@ For example:
 
 This will install the plugin version matching the current engine version used by the CLI. The next time you run `imposter up`, the plugin will be available.
 
-### Configuring default plugins
+### Configuring plugins to install
 
 If you are running Imposter using the CLI, you can list plugins in your `.imposter.yaml` file (in the config directory) or in your global CLI config at `$HOME/.imposter/config.yaml`, so they are automatically installed when you run `imposter up`:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -62,7 +62,7 @@ This will install the plugin version matching the current engine version used by
 
 ### Configuring default plugins
 
-You can list plugins in your `.imposter.yaml` file (in the config directory) or in your global CLI config at `$HOME/.imposter/config.yaml`, so they are automatically installed when you run `imposter up`:
+If you are running Imposter using the CLI, you can list plugins in your `.imposter.yaml` file (in the config directory) or in your global CLI config at `$HOME/.imposter/config.yaml`, so they are automatically installed when you run `imposter up`:
 
 ```yaml
 plugins:


### PR DESCRIPTION
## Summary
Added documentation for configuring default plugins in Imposter CLI configuration files, allowing users to automatically install plugins when running `imposter up`.

Depends on https://github.com/imposter-project/imposter-cli/pull/148

## Changes
- Added new "Configuring default plugins" section to the plugins documentation
- Documented support for specifying plugins in `.imposter.yaml` (project config) or `$HOME/.imposter/config.yaml` (global CLI config)
- Provided example YAML configuration showing how to list plugins for automatic installation

## Details
This documentation clarifies an existing feature that allows users to declare their required plugins in configuration files rather than installing them manually each time. The plugins listed will be automatically installed when `imposter up` is executed, improving the developer experience for CLI users.