### PR TITLE
docs: add brew trust command to Homebrew installation instructions

### DIFF
--- a/docs/blog/mocking-grpc-services-with-imposter.md
+++ b/docs/blog/mocking-grpc-services-with-imposter.md
@@ -85,6 +85,7 @@ The gRPC plugin is an external plugin available in Imposter 5.x. The easiest way
 
 ```bash
 brew tap imposter-project/imposter
+brew trust imposter-project/imposter
 brew install imposter
 ```
 

--- a/docs/run_imposter_cli.md
+++ b/docs/run_imposter_cli.md
@@ -46,6 +46,7 @@ The CLI itself has no dependencies. Additional prerequisites depend on the [engi
 If you have Homebrew installed:
 
     brew tap imposter-project/imposter
+    brew trust imposter-project/imposter
     brew install imposter
 
 <details markdown>
@@ -56,6 +57,7 @@ If you previously installed Imposter using Homebrew from the deprecated tap `gat
 ```shell
 brew untap gatehill/imposter
 brew tap imposter-project/imposter
+brew trust imposter-project/imposter
 ```
 
 </details>


### PR DESCRIPTION
## Summary
Updated Homebrew installation documentation to include the `brew trust` command for the imposter-project/imposter tap, which is required for proper tap verification.

## Changes
- Added `brew trust imposter-project/imposter` command to the main Homebrew installation instructions in `docs/run_imposter_cli.md`
- Added `brew trust imposter-project/imposter` command to the tap migration instructions for users upgrading from the deprecated `gatehill/imposter` tap
- Added `brew trust imposter-project/imposter` command to the gRPC plugin installation instructions in `docs/blog/mocking-grpc-services-with-imposter.md`

## Details
The `brew trust` command is necessary to establish trust for third-party taps in newer versions of Homebrew. This ensures users can successfully install Imposter without encountering tap verification errors during the installation process.