### PR TITLE
docs: document the project configuration file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Agent guide
+
+This repository holds the user-facing documentation for Imposter — published to
+[docs.imposter.sh](https://docs.imposter.sh/) via MkDocs — along with examples and
+supporting tooling.
+
+## Documentation is the source of truth here
+
+User-facing product documentation for the whole Imposter project lives in this
+repo. Prefer adding or updating user docs here rather than in the individual tool
+repositories (such as `imposter-cli`), which should link to docs.imposter.sh
+instead of duplicating content. Maintainer- and developer-only material (build
+steps, internal design, contributing notes) belongs in the relevant tool's own
+repo.
+
+## Adding or changing a docs page
+
+Pages live under `docs/` as Markdown. When you add a new page, wire it into both:
+
+- `mkdocs.yml` — add an entry under the appropriate `nav:` section
+- `docs/index.md` — add a link under the matching heading
+
+Match the surrounding pages: task-oriented and user-focused, with `> **Note**`
+callouts and a `## What's next` footer where it helps. Cross-link related pages
+with relative links (e.g. `./scaffold.md`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,10 @@ supporting tooling.
 
 User-facing product documentation for the whole Imposter project lives in this
 repo. Prefer adding or updating user docs here rather than in the individual tool
-repositories (such as `imposter-cli`), which should link to docs.imposter.sh
-instead of duplicating content. Maintainer- and developer-only material (build
-steps, internal design, contributing notes) belongs in the relevant tool's own
-repo.
+repositories (such as `imposter-cli`, `imposter-jvm-engine` or `imposter-go`),
+which should link to docs.imposter.sh instead of duplicating content.
+Maintainer- and developer-only material (build steps, internal design, contributing
+notes) belongs in the relevant tool's own repo.
 
 ## Adding or changing a docs page
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,19 @@ Pages live under `docs/` as Markdown. When you add a new page, wire it into both
 Match the surrounding pages: task-oriented and user-focused, with `> **Note**`
 callouts and a `## What's next` footer where it helps. Cross-link related pages
 with relative links (e.g. `./scaffold.md`).
+
+## Previewing and validating docs
+
+`scripts/local-docs.sh` builds the docs site in Docker and serves it locally at
+<http://localhost:8000> (set `DETACH=1` to run it in the background). To validate a
+change without serving, run a build against the same image:
+
+```bash
+docker build --file=docs/infrastructure/Dockerfile --tag=imposter-docs docs
+docker run --rm --entrypoint mkdocs \
+  -v "$PWD/mkdocs.yml:/docs/mkdocs.yml:ro" -v "$PWD/docs:/docs/docs:ro" \
+  imposter-docs build --site-dir /tmp/site
+```
+
+Check the output for broken-link warnings and confirm new pages are not reported
+as missing from the nav.

--- a/docs/bundle.md
+++ b/docs/bundle.md
@@ -64,7 +64,7 @@ $ zip -ur imposter-awslambda.zip config
   adding: config/mock.txt (deflated 22%)
 ```
 
-> **Note**
+> [!NOTE]
 > This command updates the existing ZIP file.
 
 The `imposter-awslambda.zip` file can be [deployed to AWS Lambda](./run_imposter_aws_lambda.md) as normal.
@@ -103,7 +103,7 @@ This command created a container image called `example/mock:v1` containing the c
 
 This is a standard Docker container image, so you can push it to a registry and run it anywhere Docker runs.
 
-> **Note**
+> [!NOTE]
 > The container image in this example is tagged as `example/mock:v1` but you can specify any valid container name as the `-o NAME` option. 
 
 Run the container:

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -2,7 +2,7 @@
 
 If you're using a CI/CD platform other than GitHub Actions, you can still run Imposter to mock your dependencies during testing.
 
-> **Note**
+> [!NOTE]
 > If you use GitHub Actions, there is a dedicated integration - see [Running in GitHub Actions](./github_actions.md).
 
 <details markdown>
@@ -51,7 +51,7 @@ test:
     - echo "Running tests against mock server at $IMPOSTER_BASE_URL"
 ```
 
-> **Note**
+> [!NOTE]
 > GitLab service containers cannot bind-mount repository files directly. Either bake your config into a custom image (`FROM outofcoffee/imposter`, see [Docker](./run_imposter_docker.md)), or use the CLI approach below.
 
 ## CircleCI

--- a/docs/config_discovery.md
+++ b/docs/config_discovery.md
@@ -14,7 +14,7 @@ This will load all configuration files from the configuration directory and all 
 
 ### Recursive config scan performance
 
-> **Warning**
+> [!WARNING]
 > When using recursive scan for configuration, directories with many files or subdirectories (such as `node_modules`) can significantly slow down Imposter startup time.
 
 Typically, you would not store your Imposter configuration files within a directory such as `node_modules`, so it is safe to ignore such paths when scanning for configuration files. The mechanism for this is a file named `.imposterignore`

--- a/docs/config_location.md
+++ b/docs/config_location.md
@@ -18,7 +18,7 @@ To load configuration files from a directory, pass the path to the directory in 
 imposter up /path/to/config/dir
 ```
 
-> **Note**
+> [!NOTE]
 > If no directory is specified, Imposter will use the current working directory.
 
 ### S3

--- a/docs/cors.md
+++ b/docs/cors.md
@@ -9,7 +9,7 @@ cors:
   allowOrigins: all
 ```
 
-> **Warning**
+> [!WARNING]
 > This will allow all origins to make requests to the mock endpoint. This is not recommended for production use.
 
 ## Specifying allowed origins

--- a/docs/deploy_aws_lambda_cli.md
+++ b/docs/deploy_aws_lambda_cli.md
@@ -28,7 +28,7 @@ $ ls -l
 mock-config.yaml   response.txt
 ```
 
-> **Note**
+> [!NOTE]
 > See the [Configuration section](./configuration.md) for more information.
 
 #### Step 1: Prepare your workspace
@@ -90,7 +90,7 @@ Now the remote is configured, deploy the Lambda function:
 $ imposter remote deploy
 ```
 
-> **Note**
+> [!NOTE]
 > The deploy command uses the standard AWS mechanisms for locating credentials. For example, you may have set environment variables, or use the `~/.aws/` directory, or an instance role if running within EC2.
 >
 > If you receive a credential error, check that:
@@ -120,7 +120,7 @@ $ curl https://url-to-invoke-lambda-function/system/status
 { "status": "ok" }
 ```
 
-> **Note**
+> [!NOTE]
 > If you receive the following error:
 > 
 > ```
@@ -147,7 +147,7 @@ Hello world!
 
 If you need to change a configuration option, such as memory, use the `imposter remote config` command and then run `imposter remote deploy` again.
 
-> **Note**
+> [!NOTE]
 > If you change the function name of your Lambda after deployment, future deployments will use the new name. This means that the old function with the previous name will still exist. Depending on your use case this may or may not be what you want to happen.
 
 ---

--- a/docs/failure_simulation.md
+++ b/docs/failure_simulation.md
@@ -8,7 +8,7 @@ Failures can be injected via configuration or using a script driven approach.
 
 The failure takes effect _after_ any request processing has completed (scripts, plugins etc.) but before the response is sent.
 
-> **Note**
+> [!NOTE]
 > Failures can also be combined with [performance simulation](./performance_simulation.md) effects. For example to simulate a delay followed by a closed connection.
 
 The supported failure types are:

--- a/docs/fake_data.md
+++ b/docs/fake_data.md
@@ -51,7 +51,7 @@ Some common examples:
 | Country        | `fake.Address.country`         |
 | Phone number   | `fake.PhoneNumber.phoneNumber` |
 
-> **Note**
+> [!NOTE]
 > Valid values are those supported by the [Datafaker](https://github.com/datafaker-net/datafaker) library.
 
 #### Try it out
@@ -73,7 +73,7 @@ curl http://localhost:8080/users/1
 
 ### Fake data in OpenAPI specs
 
-> **Note**
+> [!NOTE]
 > This section applies to the [OpenAPI plugin](openapi_plugin.md).
 
 When using the `fake-data` plugin with the OpenAPI plugin, common property names in the OpenAPI specification, such as `firstName`, `email` etc., are replaced with fake data. This happens when no matching example is found in the specification.
@@ -115,5 +115,5 @@ favouriteColour:
   x-fake-data: Color.name
 ```
 
-> **Note**
+> [!NOTE]
 > Valid values are those supported by the [Datafaker](https://github.com/datafaker-net/datafaker) library.

--- a/docs/github_actions.md
+++ b/docs/github_actions.md
@@ -2,7 +2,7 @@
 
 If you're using GitHub Actions for your CI/CD pipeline, you can run Imposter to mock your dependencies during testing.
 
-> **Note**
+> [!NOTE]
 > Using a different CI/CD platform? See [Running in CI/CD pipelines](./ci_cd.md) for GitLab CI, CircleCI, Jenkins, Azure Pipelines and others.
 
 <details markdown>
@@ -30,7 +30,7 @@ This guide will show you how to start and stop mocks with GitHub Actions.
 
 ## Available Actions
 
-> **Note**
+> [!NOTE]
 > Replace `v1` in the examples below with the [latest release](https://github.com/imposter-project/imposter-github-action/releases) of the GitHub Actions.
 
 ### 1. Setup Imposter (`setup`)

--- a/docs/groovy_debugging.md
+++ b/docs/groovy_debugging.md
@@ -14,7 +14,7 @@ Enable the JVM debugger with the following environment variable:
 
     JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000"
 
-> **Note**
+> [!NOTE]
 > Here we have set the debug port to 8000.
 
 ### Docker users

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ To begin, check out the [Getting started](getting_started.md) guide. See the _Co
 
 - [Configuration guide](configuration.md)
 - [Configuration location](config_location.md)
+- [Project configuration file](project_config.md)
 - [Scaffolding configuration](scaffold.md)
 - [Environment variables](environment_variables.md)
 - [Proxy an existing endpoint](proxy_endpoint.md)

--- a/docs/infrastructure/requirements.txt
+++ b/docs/infrastructure/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs-material~=9.5
 mkdocs-mermaid2-plugin~=1.1
+mkdocs-callouts~=1.16

--- a/docs/performance_simulation.md
+++ b/docs/performance_simulation.md
@@ -10,7 +10,7 @@ The delay controls the time added _after_ any request processing has completed (
 
 Delays can be specified as an exact value, or a range. If a range is specified, then a random value (roughly uniformly distributed) will be selected between the minimum and maximum range values.
 
-> **Note**
+> [!NOTE]
 > Delays can also be combined with [failure simulation](./failure_simulation.md) effects. For example to simulate a delay followed by a closed connection.
 
 ### Configuration driven

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -63,7 +63,7 @@ This will install the plugin version matching the current engine version used by
 
 ### Configuring plugins to install
 
-If you are running Imposter using the CLI, you can list plugins in your `.imposter.yaml` file (in the config directory) or in your global CLI config at `$HOME/.imposter/config.yaml`, so they are automatically installed when you run `imposter up`:
+If you are running Imposter using the CLI, you can list plugins in your [project configuration file](./project_config.md) (`imposter-project.yaml`, in the config directory) or in your global CLI config at `$HOME/.imposter/config.yaml`, so they are automatically installed when you run `imposter up`:
 
 ```yaml
 plugins:

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -1,0 +1,53 @@
+# Project configuration file
+
+When you run mocks with the [Imposter CLI](./run_imposter_cli.md), you can add a project configuration file to your mock directory to control how that project runs — for example, pinning the Imposter engine version, listing the plugins it needs, and setting environment variables. Because the file lives alongside your mocks, you can commit it to version control so everyone on your team runs the mocks the same way.
+
+> **Note**
+> This file is separate from your [mock configuration files](./configuration.md) (the `-config.yaml` files that define responses). It configures the CLI, not the mock behaviour.
+
+## File name
+
+Name the file `imposter-project.yaml` (a `.yml` or `.json` extension also works) and place it in your mock directory:
+
+```
+imposter-project.yaml
+```
+
+Running [`imposter scaffold`](./scaffold.md) creates this file for you.
+
+## Example
+
+```yaml
+# pin the engine version so everyone runs the same build
+version: "3.2.1"
+
+# install the plugins this project needs
+plugins:
+  - store-dynamodb
+
+# set environment variables when the mocks run
+env:
+  IMPOSTER_LOG_LEVEL: DEBUG
+```
+
+See the [environment variables](./environment_variables.md) reference for values you can set under `env`.
+
+## How settings are combined
+
+Imposter reads settings from several places. Where the same setting appears more than once, the later source wins:
+
+1. Your global CLI configuration (`$HOME/.imposter/config.yaml`)
+2. The project configuration file in your mock directory
+3. Environment variables
+4. Command line flags
+
+So a value in `imposter-project.yaml` overrides your global default, and a command line flag overrides the file.
+
+## Backward compatibility
+
+Earlier versions used a hidden file named `.imposter.yaml`. That name still works, but is deprecated: when Imposter finds one it prints a warning asking you to rename it to `imposter-project.yaml`. If both files are present, `imposter-project.yaml` takes precedence.
+
+## What's next
+
+- Generate a mock and project file with [scaffolding](./scaffold.md)
+- Set defaults that apply to every project using [environment variables](./environment_variables.md)

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -3,7 +3,7 @@
 When you run mocks with the [Imposter CLI](./run_imposter_cli.md), you can add a project configuration file to your mock directory to control how that project runs — for example, pinning the Imposter engine version, listing the plugins it needs, and setting environment variables. Because the file lives alongside your mocks, you can commit it to version control so everyone on your team runs the mocks the same way.
 
 > **Note**
-> This file is separate from your [mock configuration files](./configuration.md) (the `-config.yaml` files that define responses). It configures the CLI, not the mock behaviour.
+> This file is separate from your [mock configuration files](./configuration.md) (the `-config.yaml` files that define responses). It configures the engine version, plugins and environment variables, not the mock behaviour.
 
 ## File name
 
@@ -13,7 +13,7 @@ Name the file `imposter-project.yaml` (a `.yml` or `.json` extension also works)
 imposter-project.yaml
 ```
 
-Running [`imposter scaffold`](./scaffold.md) creates this file for you.
+> [Running [`imposter scaffold`](./scaffold.md) creates this file for you.
 
 ## Example
 

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -2,7 +2,7 @@
 
 When you run mocks with the [Imposter CLI](./run_imposter_cli.md), you can add a project configuration file to your mock directory to control how that project runs — for example, pinning the Imposter engine version, listing the plugins it needs, and setting environment variables. Because the file lives alongside your mocks, you can commit it to version control so everyone on your team runs the mocks the same way.
 
-> **Note**
+> [!NOTE]
 > This file is separate from your [mock configuration files](./configuration.md) (the `-config.yaml` files that define responses). It configures the engine version, plugins and environment variables, not the mock behaviour.
 
 ## File name
@@ -13,7 +13,7 @@ Name the file `imposter-project.yaml` (a `.yml` or `.json` extension also works)
 imposter-project.yaml
 ```
 
-> **Tip**
+> [!TIP]
 > Running [`imposter scaffold`](./scaffold.md) creates this file for you.
 
 ## Example

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -13,7 +13,8 @@ Name the file `imposter-project.yaml` (a `.yml` or `.json` extension also works)
 imposter-project.yaml
 ```
 
-> [Running [`imposter scaffold`](./scaffold.md) creates this file for you.
+> **Tip**
+> Running [`imposter scaffold`](./scaffold.md) creates this file for you.
 
 ## Example
 
@@ -36,8 +37,8 @@ See the [environment variables](./environment_variables.md) reference for values
 
 Imposter reads settings from several places. Where the same setting appears more than once, the later source wins:
 
-1. Your global CLI configuration (`$HOME/.imposter/config.yaml`)
-2. The project configuration file in your mock directory
+1. Your global CLI configuration (`$HOME/.imposter/config.yaml`), if it exists
+2. The project configuration file in your mock directory, if it exists
 3. Environment variables
 4. Command line flags
 

--- a/docs/request_matching.md
+++ b/docs/request_matching.md
@@ -33,7 +33,7 @@ The following operators are supported:
 | `Matches`     | Checks if the expression result matches the regular expression specified in the `value` field.        |
 | `NotMatches`  | Checks if the expression result does not match the regular expression specified in the `value` field. |
 
-> **Note**
+> [!NOTE]
 > If no `operator` is specified, then `EqualTo` is used.
 
 ---
@@ -316,7 +316,7 @@ resources:
     statusCode: 400
 ```
 
-> **Note**
+> [!NOTE]
 > If no `operator` is specified, then `EqualTo` is used.
 
 ## Matching using expressions

--- a/docs/run_imposter_jar.md
+++ b/docs/run_imposter_jar.md
@@ -2,7 +2,7 @@
 
 There are many ways to run Imposter. This section describes how to use a JAR file on the JVM.
 
-> **Note**
+> [!NOTE]
 > The JAR distribution applies to Imposter 4.x and earlier only. From Imposter 5.x onwards, Imposter is distributed as a native binary with no JVM dependency — see [Imposter CLI](./run_imposter_cli.md).
 
 <details markdown>

--- a/docs/scheduled_tasks.md
+++ b/docs/scheduled_tasks.md
@@ -6,7 +6,7 @@ description: Run periodic tasks such as webhook-style HTTP pushes
 
 # Scheduled tasks
 
-> **Note**
+> [!NOTE]
 > Schedules are available in Imposter 5.x (the `imposter-go` engine). They are not available in 4.x.
 
 Schedules let a mock *initiate* actions on a timer, independent of any inbound request. A common use is sending webhook-style HTTP notifications to another system while the mock is running.

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -33,7 +33,7 @@ For example:
     ...
     201 Created
 
-> **Note**
+> [!NOTE]
 > See this [rest plugin example](https://github.com/imposter-project/examples/blob/main/rest/conditional-scripted) for a simple example.
 
 ### Another example
@@ -259,7 +259,7 @@ respond().withExampleName('example1')
 
 This selects the example from the OpenAPI `examples` section for the API response.
 
-> **Note**
+> [!NOTE]
 > See this [openapi plugin example](https://github.com/imposter-project/examples/blob/main/openapi/scripted-named-example) for a simple example.
 
 ### Using stores

--- a/docs/scripting_legacy_js.md
+++ b/docs/scripting_legacy_js.md
@@ -8,7 +8,7 @@ To use the Nashorn JavaScript engine, you need to be running Imposter v4.0.0 or 
 
 ### Option 1: Using the CLI
 
-> **Note**
+> [!NOTE]
 > This option requires the [Imposter CLI](./run_imposter_cli.md) version 0.37.0 or later.
 
 To use this plugin, install it with the Imposter CLI:
@@ -37,7 +37,7 @@ export IMPOSTER_JS_PLUGIN=js-nashorn
 
 ## Example
 
-> **Note**
+> [!NOTE]
 > Complete the prerequisites first.
 
 Start the mock server with the `js-nashorn` engine:

--- a/docs/security.md
+++ b/docs/security.md
@@ -160,7 +160,7 @@ If you want to control the logical operator you can use the extended form as fol
 
 Here, the value of the `example` query parameter is specified as a child property named `value`. The `operator` is also specified in this form, such as `EqualTo` or `NotEqualTo`.
 
-> **Note**
+> [!NOTE]
 > If no `operator` is specified, then `EqualTo` is used.
 
 The following operators are supported:

--- a/docs/soap_plugin.md
+++ b/docs/soap_plugin.md
@@ -245,7 +245,7 @@ resources:
       statusCode: 500
 ```
 
-> **Tip**
+> [!TIP]
 > Use conditional matching with resources, to only return a fault in particular circumstances.
 > See [fault-example](https://github.com/imposter-project/examples/blob/main/soap/fault-example) for an example of how to do this.
 

--- a/docs/steps.md
+++ b/docs/steps.md
@@ -17,14 +17,14 @@ Imposter supports the following step types:
 
 The `script` step type allows you to execute a script. The script has access to the request context and stores. Script code can be inline or in an external file.
 
-> **Note**
+> [!NOTE]
 > See the [scripting](./scripting.md) section for more information about writing scripts.
 
 #### Inline script
 
 Here is an example of an inline script.
 
-> **Note**
+> [!NOTE]
 > Inline scripts can be written in JavaScript or Groovy.
 > Set the `lang` property to either `javascript` or `groovy`
 
@@ -67,7 +67,7 @@ resources:
 
 Scripts can be stored in an external file. Here is an example of an external script.
 
-> **Note**
+> [!NOTE]
 > External scripts can be written in JavaScript or Groovy.
 
 Let's assume you have a file named `example.js` with the following content:
@@ -204,7 +204,7 @@ resources:
         console.log('Remote HTTP response status code: ' + stores.request.statusCode);
 ```
 
-> **Note**
+> [!NOTE]
 > Remember that the `request` store is ephemeral, and holds values for the current, in-flight request. See the [Stores documentation](./stores.md) for details.
 
 ### Example: Use previous step output in the mock response
@@ -235,5 +235,5 @@ resources:
     content: "${stores.request.responseBody}"
 ```
 
-> **Note**
+> [!NOTE]
 > Remember that the `request` store is ephemeral, and holds values for the current, in-flight request. See the [Stores documentation](./stores.md) for details.

--- a/docs/tips_tricks.md
+++ b/docs/tips_tricks.md
@@ -17,7 +17,7 @@ You can pin the version of Imposter so you always get the same engine version.
 You can do this in a few ways using [the CLI](run_imposter_cli.md):
 
 1. Pass the `--version x.y.z` argument to `imposter up`, or
-2. Set `version: x.y.z` in an `imposter-project.yaml` file in the config directory, or
+2. Set `version: x.y.z` in an [`imposter-project.yaml`](project_config.md) file in the config directory, or
 3. Set `version: x.y.z` in your `$HOME/imposter/config.yaml` file
 
 If you're using the Imposter [GitHub Actions](github_actions.md) in your CI/CD workflow, you can:

--- a/docs/tips_tricks.md
+++ b/docs/tips_tricks.md
@@ -17,13 +17,13 @@ You can pin the version of Imposter so you always get the same engine version.
 You can do this in a few ways using [the CLI](run_imposter_cli.md):
 
 1. Pass the `--version x.y.z` argument to `imposter up`, or
-2. Set `version: x.y.z` in an `.imposter.yaml` file in the config directory, or
+2. Set `version: x.y.z` in an `imposter-project.yaml` file in the config directory, or
 3. Set `version: x.y.z` in your `$HOME/imposter/config.yaml` file
 
 If you're using the Imposter [GitHub Actions](github_actions.md) in your CI/CD workflow, you can:
 
 1. Set the `version` input to the `imposter-github-action/start-mocks` action, or
-2. Set `version: x.y.z` in an `.imposter.yaml` file in the config directory
+2. Set `version: x.y.z` in an `imposter-project.yaml` file in the config directory
 
 ## Using a local Imposter JAR with the CLI
 

--- a/docs/usage_jar.md
+++ b/docs/usage_jar.md
@@ -2,10 +2,10 @@
 
 When you are using the [JAR approach](run_imposter_jar.md), some options can be controlled using command line arguments.
 
-> **Note**
+> [!NOTE]
 > The JAR distribution applies to Imposter 4.x and earlier only. Imposter 5.x onwards is distributed as a native binary — see [Imposter CLI](./run_imposter_cli.md).
 
-> **Note**
+> [!NOTE]
 > If you are using the CLI, see [this documentation](https://github.com/imposter-project/imposter-cli/blob/main/README.md) for a list of command line arguments.
 
 ## Available arguments

--- a/docs/websocket_plugin.md
+++ b/docs/websocket_plugin.md
@@ -8,7 +8,7 @@ description: Imposter WebSocket mock plugin
 
 Plugin name: `websocket`
 
-> **Note**
+> [!NOTE]
 > This plugin is available in Imposter 5.x (the `imposter-go` engine). It is not available in 4.x.
 
 The WebSocket plugin mocks WebSocket APIs. Clients connect over a standard WebSocket upgrade, then the mock can:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
   - Configuration:
     - Configuration guide: 'configuration.md'
     - Configuration location: 'config_location.md'
+    - Project configuration file: 'project_config.md'
     - Scaffolding configuration: 'scaffold.md'
     - Environment variables: 'environment_variables.md'
     - Proxy an existing endpoint: 'proxy_endpoint.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,9 +7,15 @@ site_name: Imposter Mocks
 
 plugins:
   - search
+  # Converts GitHub/Obsidian-style '> [!NOTE]' callouts into Material
+  # admonitions. Requires the 'admonition' and 'pymdownx.details' extensions
+  # below to render them.
+  - callouts
 
 markdown_extensions:
   - md_in_html
+  - admonition
+  - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
Add user-facing documentation for the `imposter-project.yaml` project configuration file, matching the Imposter CLI's new canonical config file name.

## Summary

- Add a dedicated **Project configuration file** page describing how to pin the engine version, declare plugins, and set environment variables per project, how settings are combined, and the deprecation of the old hidden `.imposter.yaml` name.
- Wire the new page into the MkDocs nav (Configuration section) and the docs index.
- Update the plugins page and version-pinning tips to reference `imposter-project.yaml` and link to the new page.
- Add an `AGENTS.md` recording that this repo is the source of truth for user-facing documentation, and how to wire in a new page.